### PR TITLE
feat: CompanyMypage 마크업 및 전역상태 제외한 기능 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -111,6 +111,11 @@ const GlobalStyles = createGlobalStyle`
       outline: none;
     }
   }
+  input::-webkit-outer-spin-button,
+  input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
 `;
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -83,15 +83,18 @@ const GlobalStyles = createGlobalStyle`
     }
     .sub-title {
       font-size: 1.3rem;
-      font-weight: 500;
+      font-weight: 700;
     }
     .text {
-      font-size: 1rem;
+      font-size: 1.125rem;
     }
     .text-sm {
       font-size: 0.8rem;
     }
   }
+  ol, ul {
+	list-style: none;
+}
   a {
     display: block;
     text-decoration: none;

--- a/src/components/routes/CompanyMypage.tsx
+++ b/src/components/routes/CompanyMypage.tsx
@@ -1,5 +1,319 @@
+import axios from "axios";
+import { useRef, useState } from "react";
+import { CiEdit } from "react-icons/ci";
+import { GiSaveArrow } from "react-icons/gi";
+import { HiOutlinePlus } from "react-icons/hi2";
+import { IoMdClose } from "react-icons/io";
+import { Link } from "react-router-dom";
+import styled from "styled-components";
+
+const infoTitles = [
+  "대표자",
+  "설립년도",
+  "주소",
+  "사원수",
+  "회사 홈페이지 URL",
+];
+
+interface ICompanyInfo {
+  boss: string;
+  company_age: number;
+  address: string;
+  employees: number;
+  company_url: string;
+  created_at: number;
+  updated_at: number;
+}
+
 const CompanyMypage = () => {
-  return <></>;
+  /* todo: api 회사정보(info) 받아오기, 채용공고 목록 받아오기 */
+  const [info, setInfo] = useState<ICompanyInfo>();
+  const [editMode, setEditMode] = useState(false);
+  const [bossValue, setBossValue] = useState("");
+  const [ageValue, setAgeValue] = useState("");
+  const [addressValue, setAddressValue] = useState("");
+  const [employeesValue, setEmployeesValue] = useState("");
+  const [urlValue, setUrlValue] = useState("");
+  const firstInputRef = useRef<HTMLInputElement>(null);
+
+  const values = [bossValue, ageValue, addressValue, employeesValue, urlValue];
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const {
+      target: { name, value },
+    } = e;
+    if (name === "대표자") {
+      setBossValue(value);
+    } else if (name === "설립년도") {
+      setAgeValue(value);
+    } else if (name === "주소") {
+      setAddressValue(value);
+    } else if (name === "사원수") {
+      setEmployeesValue(value);
+    } else if (name === "회사 홈페이지 URL") {
+      setUrlValue(value);
+    }
+  };
+
+  const cancelEdit = () => {
+    setEditMode((edit) => !edit);
+  };
+
+  const saveInfo = async () => {
+    try {
+      if (info) {
+        await axios.put(`/companies/${companyKey}/information`, {
+          employees: employeesValue,
+          company_age: ageValue,
+          company_url: urlValue,
+          boss: bossValue,
+          address: addressValue,
+        });
+      } else {
+        await axios.post(`/companies/${companyKey}/information`, {
+          employees: employeesValue,
+          company_age: ageValue,
+          company_url: urlValue,
+          boss: bossValue,
+          address: addressValue,
+        });
+      }
+      setEditMode((edit) => !edit);
+    } catch (error) {
+      alert("회원 정보를 저장하는데 문제가 발생했습니다. 다시 시도해주세요.");
+    }
+  };
+
+  const editInfo = () => {
+    setEditMode((edit) => !edit);
+    firstInputRef.current?.focus();
+  };
+
+  return (
+    <Wrapper>
+      <Inner className="inner-1200">
+        <UserName className="title">{"(주)회사 이름"}</UserName>
+        <Container>
+          <Top>
+            <SubTitle className="sub-title">회사 정보</SubTitle>
+            <Buttons>
+              {editMode ? (
+                <>
+                  <Button className="cancel" onClick={cancelEdit}>
+                    <IoMdClose />
+                  </Button>
+                  <Button className="save" onClick={saveInfo}>
+                    <GiSaveArrow />
+                  </Button>
+                </>
+              ) : (
+                <Button className="edit" onClick={editInfo}>
+                  <CiEdit />
+                </Button>
+              )}
+            </Buttons>
+          </Top>
+          <UserInfo>
+            {editMode
+              ? infoTitles.map((info, idx) => (
+                  <Info className="text">
+                    <InfoTitle>{info}</InfoTitle>
+                    {idx === 0 ? (
+                      <InfoInput ref={firstInputRef} />
+                    ) : (
+                      <InfoInput
+                        type="text"
+                        name={info}
+                        value={values[idx]}
+                        onChange={onChange}
+                      />
+                    )}
+                  </Info>
+                ))
+              : infoTitles.map((info) => (
+                  <Info className="text">
+                    <InfoTitle>{info}</InfoTitle>
+                    <InfoDesc>{info}</InfoDesc>
+                  </Info>
+                ))}
+          </UserInfo>
+        </Container>
+        <Container>
+          <Top>
+            <SubTitle className="sub-title">등록한 채용 공고 목록</SubTitle>
+            <CreatePost to="/create-jobpost">
+              <HiOutlinePlus />
+            </CreatePost>
+          </Top>
+          <RecruitLists>
+            <RecruitList>
+              <LabelWrap>
+                <Label />
+                <Dday>{"D-3"}</Dday>
+              </LabelWrap>
+              <ListTitle>
+                {
+                  "제목입니다ㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏ"
+                }
+              </ListTitle>
+              <ListCareer>{"경력"}</ListCareer>
+              <ListStep>{"서류 접수중"}</ListStep>
+            </RecruitList>
+            <RecruitList>
+              <LabelWrap>
+                <Label />
+                <Dday>{"D-3"}</Dday>
+              </LabelWrap>
+              <ListTitle>
+                {
+                  "제목입니다ㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏ"
+                }
+              </ListTitle>
+              <ListCareer>{"경력"}</ListCareer>
+              <ListStep>{"서류 접수중"}</ListStep>
+            </RecruitList>
+          </RecruitLists>
+        </Container>
+      </Inner>
+    </Wrapper>
+  );
 };
+
+const Wrapper = styled.div`
+  padding-top: 120px;
+`;
+
+const Inner = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 60px;
+`;
+
+const UserName = styled.h2``;
+
+const Container = styled.div``;
+
+const Top = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 24px;
+`;
+
+const Buttons = styled.div`
+  display: flex;
+  gap: 0.5rem;
+`;
+
+const Button = styled.button`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: var(--button-radius);
+  font-size: 1.5rem;
+
+  &.cancel {
+    background-color: var(--bg-light-gray);
+    border: 1px solid var(--border-gray-100);
+  }
+  &.save {
+    background-color: #00cc21;
+  }
+  &.edit {
+    background-color: var(--primary-color);
+    color: #fff;
+  }
+`;
+
+const UserInfo = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(48%, 1fr));
+  row-gap: 40px;
+  column-gap: 4%;
+  padding: 40px;
+  background-color: var(--bg-light-blue);
+`;
+
+const Info = styled.div`
+  display: flex;
+  gap: 1rem;
+`;
+
+const InfoTitle = styled.p`
+  width: 150px;
+  font-weight: 700;
+`;
+
+const InfoInput = styled.input`
+  border: none;
+  border-bottom: 1px dashed var(--border-gray-100);
+  background-color: transparent;
+`;
+
+const InfoDesc = styled.p`
+  width: calc(100% - 150px);
+`;
+
+const SubTitle = styled.h3``;
+
+const CreatePost = styled(Link)`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: var(--button-radius);
+  background-color: var(--primary-color);
+  font-size: 1.5rem;
+  color: #fff;
+`;
+
+const RecruitLists = styled.ul`
+  display: flex;
+  flex-direction: column;
+  padding: 1rem 2rem;
+  border: 1px solid var(--border-gray-100);
+  border-radius: var(--box-radius);
+`;
+
+const RecruitList = styled.li`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 0;
+  &:not(:last-child) {
+    border-bottom: 1px solid var(--border-gray-100);
+  }
+`;
+
+const LabelWrap = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+`;
+
+const Label = styled.span`
+  display: inline-block;
+  width: 0.5rem;
+  height: 2rem;
+  background-color: #00cc21;
+`;
+
+const Dday = styled.p``;
+
+const ListTitle = styled.h4`
+  width: 450px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const ListCareer = styled.p``;
+
+const ListStep = styled.p`
+  font-weight: 700;
+`;
 
 export default CompanyMypage;

--- a/src/components/routes/CompanyMypage.tsx
+++ b/src/components/routes/CompanyMypage.tsx
@@ -15,6 +15,8 @@ const infoTitles = [
   "회사 홈페이지 URL",
 ];
 
+const infoTypes = ["text", "date", "text", "number", "text"];
+
 interface ICompanyInfo {
   boss: string;
   company_age: number;
@@ -36,6 +38,8 @@ const CompanyMypage = () => {
   const [urlValue, setUrlValue] = useState("");
   const firstInputRef = useRef<HTMLInputElement>(null);
 
+  const companyKey = "";
+  const infoURL = `/companies/${companyKey}/information`;
   const values = [bossValue, ageValue, addressValue, employeesValue, urlValue];
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -60,27 +64,28 @@ const CompanyMypage = () => {
   };
 
   const saveInfo = async () => {
-    try {
-      if (info) {
-        await axios.put(`/companies/${companyKey}/information`, {
-          employees: employeesValue,
-          company_age: ageValue,
-          company_url: urlValue,
-          boss: bossValue,
-          address: addressValue,
-        });
-      } else {
-        await axios.post(`/companies/${companyKey}/information`, {
-          employees: employeesValue,
-          company_age: ageValue,
-          company_url: urlValue,
-          boss: bossValue,
-          address: addressValue,
-        });
+    const body = {
+      employees: employeesValue,
+      company_age: ageValue,
+      company_url: urlValue,
+      boss: bossValue,
+      address: addressValue,
+    };
+    const bodyFill = Object.values(body).every((v) => v.trim());
+
+    if (bodyFill) {
+      try {
+        if (info) {
+          await axios.put(`${infoURL}`, body);
+        } else {
+          await axios.post(`${infoURL}`, body);
+        }
+        setEditMode((edit) => !edit);
+      } catch (error) {
+        alert("회원 정보를 저장하는데 문제가 발생했습니다. 다시 시도해주세요.");
       }
-      setEditMode((edit) => !edit);
-    } catch (error) {
-      alert("회원 정보를 저장하는데 문제가 발생했습니다. 다시 시도해주세요.");
+    } else {
+      alert("회사 정보를 모두 입력해주세요.");
     }
   };
 
@@ -116,13 +121,34 @@ const CompanyMypage = () => {
           <UserInfo>
             {editMode
               ? infoTitles.map((info, idx) => (
-                  <Info className="text">
+                  <Info className="text" key={info}>
                     <InfoTitle>{info}</InfoTitle>
                     {idx === 0 ? (
-                      <InfoInput ref={firstInputRef} />
+                      <InfoInput
+                        type={infoTypes[idx]}
+                        name={info}
+                        value={values[idx]}
+                        onChange={onChange}
+                        ref={firstInputRef}
+                      />
+                    ) : infoTypes[idx] === "number" ? (
+                      <InfoInput
+                        type={infoTypes[idx]}
+                        name={info}
+                        value={values[idx]}
+                        min={0}
+                        onChange={onChange}
+                      />
+                    ) : infoTypes[idx] === "date" ? (
+                      <InfoInput
+                        type={infoTypes[idx]}
+                        name={info}
+                        value={values[idx]}
+                        onChange={onChange}
+                      />
                     ) : (
                       <InfoInput
-                        type="text"
+                        type={infoTypes[idx]}
                         name={info}
                         value={values[idx]}
                         onChange={onChange}
@@ -131,7 +157,7 @@ const CompanyMypage = () => {
                   </Info>
                 ))
               : infoTitles.map((info) => (
-                  <Info className="text">
+                  <Info className="text" key={info}>
                     <InfoTitle>{info}</InfoTitle>
                     <InfoDesc>{info}</InfoDesc>
                   </Info>
@@ -247,9 +273,23 @@ const InfoTitle = styled.p`
 `;
 
 const InfoInput = styled.input`
+  position: relative;
+  width: calc(100% - 150px);
+  padding: 2px 0;
   border: none;
   border-bottom: 1px dashed var(--border-gray-100);
   background-color: transparent;
+
+  // 캘린더 클릭 영역을 input 전체 영역으로 설정
+  &[type="date"]::-webkit-calendar-picker-indicator {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    background-position: 100% -3px;
+    cursor: pointer;
+  }
 `;
 
 const InfoDesc = styled.p`

--- a/src/components/routes/Layout.tsx
+++ b/src/components/routes/Layout.tsx
@@ -1,15 +1,20 @@
 import { Outlet } from "react-router-dom";
 import Header from "../common/Header";
+import styled from "styled-components";
 
 const Layout = () => {
   return (
     <>
       <Header />
-      <main>
+      <Main>
         <Outlet />
-      </main>
+      </Main>
     </>
   );
 };
+
+const Main = styled.main`
+  padding: 0 32px;
+`;
 
 export default Layout;


### PR DESCRIPTION
## 작업 내용

1. [회사]마이페이지 - CompanyMypage 마크업 
2. 회사정보나 채용공고 목록 불러오는건 전역상태로 user 정보 먼저 불러오고 해야할 것 같습니다
3. 전역 데이터 제외하고는 input 이벤트나 [회사정보 저장] api 요청 등은 작업해두었습니다.
4. 회사정보 작성하는 폼은 스크린샷 첨부하겠습니다 !

## 스크린샷
![image](https://github.com/cheonjiyun/auto-enterview-fe/assets/141378574/99606585-6319-4370-ada9-f4c193c43d45)
![image](https://github.com/cheonjiyun/auto-enterview-fe/assets/141378574/437fd6b7-d784-4a80-a35b-d8f323f044be)


## 리뷰 요구사항

1. Layout에 헤더를 제외한 페이지 main 영역에 양쪽 여백 추가했습니다 !
2. 하다보니 현재 user 정보가 계속 필요하네요.. 전역상태로 저장하는 방식을 함께 논의하면 좋겠습니다~!

close #19
