### PR TITLE
채용공고 폼 기능, 유효성검사

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "react-datepicker": "^7.2.0",
         "react-dom": "^18.3.1",
         "react-helmet-async": "^2.0.5",
+        "react-hook-form": "^7.52.1",
         "react-icons": "^5.2.1",
         "react-router-dom": "^6.24.0",
         "react-select": "^5.8.0",
@@ -3404,6 +3405,21 @@
       },
       "peerDependencies": {
         "react": "^16.6.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.52.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.52.1.tgz",
+      "integrity": "sha512-uNKIhaoICJ5KQALYZ4TOaOLElyM+xipord+Ha3crEFhTntdLvWZqVY49Wqd/0GiVCA/f9NjemLeiNPjG7Hpurg==",
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-icons": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react-datepicker": "^7.2.0",
     "react-dom": "^18.3.1",
     "react-helmet-async": "^2.0.5",
+    "react-hook-form": "^7.52.1",
     "react-icons": "^5.2.1",
     "react-router-dom": "^6.24.0",
     "react-select": "^5.8.0",

--- a/src/components/routes/CreateJobPost.tsx
+++ b/src/components/routes/CreateJobPost.tsx
@@ -1,10 +1,36 @@
 import styled from "styled-components";
 import Select from "react-select";
 import DatePicker from "react-datepicker";
-import { useState } from "react";
+import React, { useRef, useState } from "react";
 import { Helmet } from "react-helmet-async";
+import { useForm, Controller } from "react-hook-form";
 
 const CreateJobPost = () => {
+  //enum
+  const optionJob = [
+    { value: "backend", label: "서버/백엔드 개발" },
+    { value: "frontend", label: "프론트엔드 개발" },
+    { value: "fullstack", label: "웹 풀스택 개발" },
+    { value: "android", label: "안드로이드 개발" },
+    { value: "ios", label: "iOS 개발" },
+  ];
+
+  const optionEducation = [
+    { value: "no", label: "학력무관" },
+    { value: "middle", label: "중졸 이하" },
+    { value: "high", label: "고졸" },
+    { value: "associate", label: "대학 2,3년제" },
+    { value: "bachelor", label: "대학 4년제" },
+    { value: "master", label: "석사" },
+    { value: "doctor", label: "박사" },
+  ];
+
+  const optionEmploymentType = [
+    { value: "intern", label: "인턴직" },
+    { value: "contract", label: "계약직" },
+    { value: "regular", label: "정규직" },
+  ];
+
   const teckStacks = [
     "Java",
     "Spring Boot",
@@ -35,11 +61,54 @@ const CreateJobPost = () => {
     "Xcode",
   ];
 
-  const [startHour, setStartHour] = useState<Date | null>(new Date(2024, 7, 13, 9, 0));
-  const [endHour, setEndHour] = useState<Date | null>(new Date(2024, 7, 13, 18, 0));
+  //form
+  const {
+    handleSubmit,
+    register,
+    control,
+    watch,
+    formState: { errors },
+  } = useForm();
 
-  const [startDate, setStartDate] = useState<Date | null>(new Date());
-  const [endDate, setEndDate] = useState<Date | null>(new Date());
+  const onSubmit = data => {
+    console.log(data);
+  };
+
+  // 필요경력, 급여같은 input에서 disable될 때 임시로 저장해두는 값
+  const inputMemory = useRef({ career: "", salary: "" });
+
+  //전형절차단계
+  const [jobPostingSteps, setJobPostingSteps] = useState(["서류전형"]);
+  const [jobPostingError, setJobPostingError] = useState("");
+  //추가
+  const [addStepValue, setAddStepValue] = useState("");
+  const addStep = (
+    event: React.ChangeEvent<HTMLInputElement> | React.KeyboardEvent<HTMLInputElement>,
+  ) => {
+    event.preventDefault();
+    if (addStepValue === "") return;
+    if (jobPostingSteps.length >= 10) {
+      setJobPostingError("최대 10단계까지 가능합니다.");
+      return;
+    }
+
+    setJobPostingSteps([...jobPostingSteps, addStepValue]);
+    setAddStepValue("");
+  };
+  //삭제
+  const deleteStep = (idx: number) => {
+    const temp = [...jobPostingSteps];
+    temp.splice(idx, 1);
+
+    setJobPostingSteps(temp);
+  };
+
+  //파일업로드
+  const [fileName, setFileName] = useState("");
+  const uploadFile = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value.split("\\");
+    setFileName(value[value.length - 1]);
+  };
 
   return (
     <>
@@ -48,241 +117,422 @@ const CreateJobPost = () => {
       </Helmet>
       <Wrapper className="inner-1200">
         <Title>채용공고 생성</Title>
-        <InputContainer>
-          <InputTitle>채용직무</InputTitle>
-          <Select
-            options={[
-              { value: "backend", label: "서버/백엔드 개발" },
-              { value: "frontend", label: "프론트엔드 개발" },
-              { value: "fullstack", label: "웹 풀스택 개발" },
-              { value: "android", label: "안드로이드 개발" },
-              { value: "ios", label: "iOS 개발" },
-            ]}
-            styles={{
-              control: (baseStyles, state) => ({
-                ...baseStyles,
-                borderColor: state.isFocused ? "#5690FB" : "#B7B7B7",
-                borderRadius: "8px",
-                padding: "6px 5px",
-              }),
-              option: (baseStyles, state) => ({
-                ...baseStyles,
-                backgroundColor: state.isFocused ? "#5690FB" : "",
-                color: state.isFocused ? "#ffffff" : "#000000",
-                padding: "8px 13px",
-              }),
-            }}
-            placeholder="채용할 직무를 선택하세요"
-          />
-        </InputContainer>
-        <InputContainer>
-          <InputTitle>제목</InputTitle>
-          <InputText type="text" placeholder="공고 제목을 입력하세요" className="text" />
-        </InputContainer>
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <InputContainer>
+            <InputTitle>채용직무</InputTitle>
+            <Controller
+              control={control}
+              name="jobCategory"
+              rules={{ required: "채용할 직무를 선택해주세요." }}
+              render={({ field: { onChange, value, ref } }) => (
+                <Select
+                  options={optionJob}
+                  styles={{
+                    control: (baseStyles, state) => ({
+                      ...baseStyles,
+                      borderColor: state.isFocused ? "#000694" : "#B7B7B7",
+                      borderRadius: "8px",
+                      padding: "6px 5px",
+                    }),
+                    option: (baseStyles, state) => ({
+                      ...baseStyles,
+                      backgroundColor: state.isFocused ? "#000694" : "",
+                      color: state.isFocused ? "#ffffff" : "#000000",
+                      padding: "8px 13px",
+                    }),
+                  }}
+                  placeholder="채용할 직무를 선택하세요"
+                  ref={ref}
+                  value={optionJob.find(option => option.value === value)}
+                  onChange={option => onChange(option?.value)}
+                />
+              )}
+            />
+            <ErrorMessage>{errors.jobCategory && String(errors.jobCategory?.message)}</ErrorMessage>
+          </InputContainer>
+          <InputContainer>
+            <InputTitle>제목</InputTitle>
+            <InputText
+              type="text"
+              placeholder="공고 제목을 입력하세요"
+              className="text"
+              {...register("title", { required: "공고 제목을 입력해주세요." })}
+            />
+            <ErrorMessage>{errors.title && String(errors.title?.message)}</ErrorMessage>
+          </InputContainer>
 
-        <InputContainer>
-          <InputTitle>필요경력</InputTitle>
-          <InputContents>
-            <InputShortText type="number" placeholder="신입은 0" className="text" />
-            <AdditionExplanation>년 이상</AdditionExplanation>
-            <Checkbox type="checkbox" id="career-year" />
-            <label htmlFor="career-year">경력무관</label>
-          </InputContents>
-        </InputContainer>
-
-        <InputContainerShortMargin>
-          <InputTitle>기술스택</InputTitle>
-          <StackInputContainer>
-            {teckStacks.map(stack => {
-              return (
-                <StackInputGroup key={stack}>
-                  <Checkboxs name="stack" type="checkbox" id={stack} />
-                  <label htmlFor={stack}>{stack}</label>
-                </StackInputGroup>
-              );
-            })}
-          </StackInputContainer>
-        </InputContainerShortMargin>
-        <InputContainer>
-          <InputTitle>주소</InputTitle>
-          <InputText type="text" placeholder="주소를 입력하세요" className="text" />
-        </InputContainer>
-        <InputContainer>
-          <InputTitle>필요학력</InputTitle>
-          <Select
-            options={[
-              { value: "no", label: "학력무관" },
-              { value: "middle", label: "중졸 이하" },
-              { value: "high", label: "고졸" },
-              { value: "associate", label: "대학 2,3년제" },
-              { value: "bachelor", label: "대학 4년제" },
-              { value: "master", label: "석사" },
-              { value: "doctor", label: "박사" },
-            ]}
-            styles={{
-              control: (baseStyles, state) => ({
-                ...baseStyles,
-                borderColor: state.isFocused ? "#5690FB" : "#B7B7B7",
-                borderRadius: "8px",
-                padding: "6px 5px",
-              }),
-              option: (baseStyles, state) => ({
-                ...baseStyles,
-                backgroundColor: state.isFocused ? "#5690FB" : "",
-                color: state.isFocused ? "#ffffff" : "#000000",
-                padding: "8px 13px",
-              }),
-            }}
-            placeholder="필요한 학력을 선택하세요"
-          />
-        </InputContainer>
-        <InputContainer>
-          <InputTitle>고용형태</InputTitle>
-          <Select
-            options={[
-              { value: "intern", label: "인턴직" },
-              { value: "contract", label: "계약직" },
-              { value: "regular", label: "정규직" },
-            ]}
-            styles={{
-              control: (baseStyles, state) => ({
-                ...baseStyles,
-                borderColor: state.isFocused ? "#5690FB" : "#B7B7B7",
-                borderRadius: "8px",
-                padding: "6px 5px",
-              }),
-              option: (baseStyles, state) => ({
-                ...baseStyles,
-                backgroundColor: state.isFocused ? "#5690FB" : "",
-                color: state.isFocused ? "#ffffff" : "#000000",
-                padding: "8px 13px",
-              }),
-            }}
-            placeholder="고용형태를 선택하세요"
-          />
-        </InputContainer>
-        <InputContainer>
-          <InputTitle>급여</InputTitle>
-
-          <InputContents>
-            <InputShortText type="number" placeholder="연봉" className="text" />
-            <Checkbox type="checkbox" id="pay" />
-            <label htmlFor="pay">회사 내규에 따름</label>
-          </InputContents>
-        </InputContainer>
-        <InputContainer>
-          <InputTitle>근무기간</InputTitle>
-          <InputContents>
-            <TimePickerContainer>
-              <DatePicker
-                selected={startHour}
-                onChange={date => setStartHour(date)}
-                showTimeSelect
-                showTimeSelectOnly
-                timeIntervals={30}
-                dateFormat="HH:mm"
-                timeFormat="HH:mm"
-                timeCaption=""
-                customInput={<TimeInput />}
-              />
-            </TimePickerContainer>
-            <p>~</p>
-            <TimePickerContainer>
-              <DatePicker
-                selected={endHour}
-                onChange={date => setEndHour(date)}
-                showTimeSelect
-                showTimeSelectOnly
-                timeIntervals={30}
-                dateFormat="HH:mm"
-                timeFormat="HH:mm"
-                timeCaption=""
-                customInput={<TimeInput />}
-              />
-            </TimePickerContainer>
-
-            <Checkbox type="checkbox" id="hourfree" />
-            <label htmlFor="hourfree">자율출근제</label>
-          </InputContents>
-        </InputContainer>
-        <InputContainer>
-          <InputTitle>접수기간</InputTitle>
-          <InputContents>
-            <DatePickerContainer>
-              <DatePicker
-                selected={startDate}
-                onChange={date => setStartDate(date)}
-                selectsStart
-                dateFormat="YYYY.MM.dd"
-                customInput={<DateInput />}
-                startDate={startDate || undefined}
-                endDate={startDate || undefined}
-              />
-            </DatePickerContainer>
-            <p>~</p>
-            <DatePickerContainer>
-              <DatePicker
-                selected={endDate}
-                onChange={date => setEndDate(date)}
-                selectsEnd
-                dateFormat="YYYY.MM.dd"
-                customInput={<DateInput />}
-                startDate={startDate || undefined}
-                endDate={endDate || undefined}
-              />
-            </DatePickerContainer>
-          </InputContents>
-        </InputContainer>
-        <InputContainer>
-          <InputTitle>전형절차</InputTitle>
-          <InputContents>
-            <StepContainer>
-              <Step>
-                <StepNumber>1단계</StepNumber>서류전형
-              </Step>
-              <Step>
-                <StepNumber>2단계</StepNumber>
-                과제전형
-                <StepDelete>
-                  <svg
-                    width="16"
-                    height="17"
-                    viewBox="0 0 16 17"
-                    fill="none"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M12.8535 12.6463C12.9 12.6927 12.9368 12.7479 12.962 12.8086C12.9871 12.8693 13.0001 12.9343 13.0001 13C13.0001 13.0657 12.9871 13.1308 12.962 13.1915C12.9368 13.2522 12.9 13.3073 12.8535 13.3538C12.8071 13.4002 12.7519 13.4371 12.6912 13.4622C12.6305 13.4874 12.5655 13.5003 12.4998 13.5003C12.4341 13.5003 12.369 13.4874 12.3083 13.4622C12.2476 13.4371 12.1925 13.4002 12.146 13.3538L7.99979 9.20691L3.85354 13.3538C3.75972 13.4476 3.63247 13.5003 3.49979 13.5003C3.36711 13.5003 3.23986 13.4476 3.14604 13.3538C3.05222 13.26 2.99951 13.1327 2.99951 13C2.99951 12.8674 3.05222 12.7401 3.14604 12.6463L7.29291 8.50003L3.14604 4.35378C3.05222 4.25996 2.99951 4.13272 2.99951 4.00003C2.99951 3.86735 3.05222 3.7401 3.14604 3.64628C3.23986 3.55246 3.36711 3.49976 3.49979 3.49976C3.63247 3.49976 3.75972 3.55246 3.85354 3.64628L7.99979 7.79316L12.146 3.64628C12.2399 3.55246 12.3671 3.49976 12.4998 3.49976C12.6325 3.49976 12.7597 3.55246 12.8535 3.64628C12.9474 3.7401 13.0001 3.86735 13.0001 4.00003C13.0001 4.13272 12.9474 4.25996 12.8535 4.35378L8.70666 8.50003L12.8535 12.6463Z"
-                      fill="#210909"
+          <InputContainer>
+            <InputTitle>필요경력</InputTitle>
+            <InputContents>
+              <Controller
+                control={control}
+                name="career"
+                rules={{ required: "필요경력을 입력해주세요." }}
+                render={({ field: { onChange, ref, value } }) => (
+                  <>
+                    <InputShortText
+                      type="number"
+                      placeholder="신입은 0"
+                      className="text"
+                      onChange={event => {
+                        onChange(event.target.value);
+                        inputMemory.current.career = event.target.value;
+                      }}
+                      ref={ref}
+                      disabled={value == -1}
                     />
-                  </svg>
-                </StepDelete>
-              </Step>
-            </StepContainer>
-            <StepInputContianer>
-              <StepInput type="text" placeholder="예) 1차 면접" className="text" />
-              <Button className="text">단계추가</Button>
-            </StepInputContianer>
-          </InputContents>
-        </InputContainer>
-        <InputContainer>
-          <TitleContainer>
-            <InputTitle>공고내용</InputTitle>
-            <Info className="text-sm">
-              **텍스트와 이미지 둘 다 작성시, 이미지는 맨 하단에 추가됩니다.
-            </Info>
-          </TitleContainer>
-          <Contents placeholder="공고내용을 입력해주세요." className="text" />
-          <FileContainer>
-            <FileName>&nbsp;</FileName>
-            <FileInput type="file" id="image" />
-            <label htmlFor="image">이미지 업로드</label>
-          </FileContainer>
-        </InputContainer>
+                    <AdditionExplanation>년 이상</AdditionExplanation>
+                    <Checkbox
+                      type="checkbox"
+                      id="career-year"
+                      onChange={event => {
+                        onChange(event.target.checked ? "-1" : inputMemory.current.career);
+                      }}
+                      ref={ref}
+                    />
+                    <label htmlFor="career-year">경력무관</label>
+                  </>
+                )}
+              />
+            </InputContents>
+            <ErrorMessage> {errors.career && String(errors.career?.message)}</ErrorMessage>
+          </InputContainer>
+
+          <InputContainerShortMargin>
+            <InputTitle>기술스택</InputTitle>
+            <Controller
+              control={control}
+              name="teckStack"
+              rules={{ required: "기술스택은 1개이상 선택해주세요." }}
+              defaultValue={[]}
+              render={({ field: { onChange, value } }) => (
+                <StackInputContainer>
+                  {teckStacks.map(stack => {
+                    return (
+                      <StackInputGroup key={stack}>
+                        <Checkboxs
+                          type="checkbox"
+                          id={stack}
+                          onChange={event => {
+                            if (event.target.checked) {
+                              // 체크하면 추가
+                              onChange([...value, stack]);
+                            } else {
+                              //해제하면 빼기
+                              const temp = value;
+                              temp.splice(stack, 1);
+                              onChange(temp);
+                            }
+                          }}
+                        />
+                        <label htmlFor={stack}>{stack}</label>
+                      </StackInputGroup>
+                    );
+                  })}
+                </StackInputContainer>
+              )}
+            />
+            <ErrorMessage> {errors.teckStack && String(errors.teckStack?.message)}</ErrorMessage>
+          </InputContainerShortMargin>
+
+          <InputContainer>
+            <InputTitle>근무지</InputTitle>
+            <InputText
+              type="text"
+              placeholder="주소를 입력하세요"
+              className="text"
+              {...register("workLocation", { required: "근무지를 입력해주세요." })}
+            />
+            <ErrorMessage>
+              {errors.workLocation && String(errors.workLocation?.message)}
+            </ErrorMessage>
+          </InputContainer>
+
+          <InputContainer>
+            <InputTitle>필요학력</InputTitle>
+            <Controller
+              control={control}
+              name="education"
+              rules={{ required: "필요학력을 선택해주세요." }}
+              render={({ field: { onChange, value, ref } }) => (
+                <Select
+                  options={optionEducation}
+                  styles={{
+                    control: (baseStyles, state) => ({
+                      ...baseStyles,
+                      borderColor: state.isFocused ? "#5690FB" : "#B7B7B7",
+                      borderRadius: "8px",
+                      padding: "6px 5px",
+                    }),
+                    option: (baseStyles, state) => ({
+                      ...baseStyles,
+                      backgroundColor: state.isFocused ? "#5690FB" : "",
+                      color: state.isFocused ? "#ffffff" : "#000000",
+                      padding: "8px 13px",
+                    }),
+                  }}
+                  placeholder="필요한 학력을 선택하세요"
+                  ref={ref}
+                  value={optionEducation.find(option => option.value === value)}
+                  onChange={option => onChange(option?.value)}
+                />
+              )}
+            />
+            <ErrorMessage>{errors.education && String(errors.education?.message)}</ErrorMessage>
+          </InputContainer>
+
+          <InputContainer>
+            <InputTitle>고용형태</InputTitle>
+            <Controller
+              control={control}
+              name="employmentType"
+              rules={{ required: "고용형태를 선택해주세요." }}
+              render={({ field: { onChange, value, ref } }) => (
+                <Select
+                  options={optionEmploymentType}
+                  styles={{
+                    control: (baseStyles, state) => ({
+                      ...baseStyles,
+                      borderColor: state.isFocused ? "#5690FB" : "#B7B7B7",
+                      borderRadius: "8px",
+                      padding: "6px 5px",
+                    }),
+                    option: (baseStyles, state) => ({
+                      ...baseStyles,
+                      backgroundColor: state.isFocused ? "#5690FB" : "",
+                      color: state.isFocused ? "#ffffff" : "#000000",
+                      padding: "8px 13px",
+                    }),
+                  }}
+                  placeholder="고용형태를 선택하세요"
+                  ref={ref}
+                  value={optionEmploymentType.find(option => option.value === value)}
+                  onChange={option => onChange(option?.value)}
+                />
+              )}
+            />
+            <ErrorMessage>
+              {errors.employmentType && String(errors.employmentType?.message)}
+            </ErrorMessage>
+          </InputContainer>
+
+          <InputContainer>
+            <InputTitle>급여</InputTitle>
+            <InputContents>
+              <Controller
+                control={control}
+                name="salary"
+                rules={{ required: "급여를 입력해주세요." }}
+                render={({ field: { onChange, ref, value } }) => (
+                  <>
+                    <InputShortText
+                      type="number"
+                      placeholder="연봉"
+                      className="text"
+                      onChange={event => {
+                        onChange(event.target.value);
+                        inputMemory.current.salary = event.target.value;
+                      }}
+                      ref={ref}
+                      disabled={value == "회사내규에따름"}
+                    />
+                    <AdditionExplanation>만원</AdditionExplanation>
+                    <Checkbox
+                      type="checkbox"
+                      id="pay"
+                      onChange={event => {
+                        onChange(
+                          event.target.checked ? "회사내규에따름" : inputMemory.current.salary,
+                        );
+                      }}
+                      ref={ref}
+                    />
+                    <label htmlFor="pay">회사 내규에 따름</label>
+                  </>
+                )}
+              />
+            </InputContents>
+            <ErrorMessage>{errors.salary && String(errors.salary?.message)}</ErrorMessage>
+          </InputContainer>
+
+          <InputContainer>
+            <InputTitle>근무기간</InputTitle>
+            <InputContents>
+              <Controller
+                control={control}
+                name="startHour"
+                rules={{ required: "근무시간을 선택해주세요." }}
+                defaultValue={new Date(2024, 7, 13, 9, 0)}
+                render={({ field: { onChange, value } }) => (
+                  <TimePickerContainer>
+                    <DatePicker
+                      selected={value}
+                      onChange={date => onChange(date)}
+                      showTimeSelect
+                      showTimeSelectOnly
+                      timeIntervals={30}
+                      dateFormat="HH:mm"
+                      timeFormat="HH:mm"
+                      timeCaption=""
+                      customInput={<TimeInput />}
+                    />
+                  </TimePickerContainer>
+                )}
+              />
+              <p>~</p>
+              <Controller
+                control={control}
+                name="endHour"
+                rules={{ required: "근무시간을 선택해주세요." }}
+                defaultValue={new Date(2024, 7, 13, 18, 0)}
+                render={({ field: { onChange, value } }) => (
+                  <TimePickerContainer>
+                    <DatePicker
+                      selected={value}
+                      onChange={date => onChange(date)}
+                      showTimeSelect
+                      showTimeSelectOnly
+                      timeIntervals={30}
+                      dateFormat="HH:mm"
+                      timeFormat="HH:mm"
+                      timeCaption=""
+                      customInput={<TimeInput />}
+                    />
+                  </TimePickerContainer>
+                )}
+              />
+              <Checkbox type="checkbox" id="hourfree" />
+              <label htmlFor="hourfree">자율출근제</label>
+            </InputContents>
+            <ErrorMessage>
+              {(errors.startHour || errors.startHour) && String(errors.startHour?.message)}
+            </ErrorMessage>
+          </InputContainer>
+
+          <InputContainer>
+            <InputTitle>접수기간</InputTitle>
+            <InputContents>
+              <Controller
+                control={control}
+                name="startDateTime"
+                rules={{ required: "접수시간을 선택해주세요." }}
+                defaultValue={new Date()}
+                render={({ field: { onChange, value } }) => (
+                  <DatePickerContainer>
+                    <DatePicker
+                      selected={value}
+                      onChange={date => onChange(date)}
+                      selectsStart
+                      dateFormat="YYYY.MM.dd"
+                      customInput={<DateInput />}
+                      startDate={watch("startDateTime")}
+                      endDate={watch("endDateTime")}
+                    />
+                  </DatePickerContainer>
+                )}
+              />
+              <p>~</p>
+              <Controller
+                control={control}
+                name="endDateTime"
+                rules={{ required: "접수시간을 선택해주세요." }}
+                defaultValue={new Date()}
+                render={({ field: { onChange, value } }) => (
+                  <DatePickerContainer>
+                    <DatePicker
+                      selected={value}
+                      onChange={date => onChange(date)}
+                      selectsEnd
+                      dateFormat="YYYY.MM.dd"
+                      customInput={<DateInput />}
+                      startDate={watch("startDateTime")}
+                      endDate={watch("endDateTime")}
+                    />
+                  </DatePickerContainer>
+                )}
+              />
+            </InputContents>
+            <ErrorMessage>
+              {(errors.startDateTime || errors.endDateTime) &&
+                String(errors.startDateTime?.message)}
+            </ErrorMessage>
+          </InputContainer>
+
+          <InputContainer>
+            <InputTitle>전형절차</InputTitle>
+            <InputContents>
+              <StepContainer>
+                {jobPostingSteps.map((jobPostingStep, idx) => {
+                  return (
+                    <Step key={`${jobPostingStep} ${idx}`}>
+                      <StepNumber>{idx + 1}단계</StepNumber>
+                      {jobPostingStep}
+                      {idx >= 1 && (
+                        <StepDelete onClick={() => deleteStep(idx)}>
+                          <svg
+                            width="16"
+                            height="17"
+                            viewBox="0 0 16 17"
+                            fill="none"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M12.8535 12.6463C12.9 12.6927 12.9368 12.7479 12.962 12.8086C12.9871 12.8693 13.0001 12.9343 13.0001 13C13.0001 13.0657 12.9871 13.1308 12.962 13.1915C12.9368 13.2522 12.9 13.3073 12.8535 13.3538C12.8071 13.4002 12.7519 13.4371 12.6912 13.4622C12.6305 13.4874 12.5655 13.5003 12.4998 13.5003C12.4341 13.5003 12.369 13.4874 12.3083 13.4622C12.2476 13.4371 12.1925 13.4002 12.146 13.3538L7.99979 9.20691L3.85354 13.3538C3.75972 13.4476 3.63247 13.5003 3.49979 13.5003C3.36711 13.5003 3.23986 13.4476 3.14604 13.3538C3.05222 13.26 2.99951 13.1327 2.99951 13C2.99951 12.8674 3.05222 12.7401 3.14604 12.6463L7.29291 8.50003L3.14604 4.35378C3.05222 4.25996 2.99951 4.13272 2.99951 4.00003C2.99951 3.86735 3.05222 3.7401 3.14604 3.64628C3.23986 3.55246 3.36711 3.49976 3.49979 3.49976C3.63247 3.49976 3.75972 3.55246 3.85354 3.64628L7.99979 7.79316L12.146 3.64628C12.2399 3.55246 12.3671 3.49976 12.4998 3.49976C12.6325 3.49976 12.7597 3.55246 12.8535 3.64628C12.9474 3.7401 13.0001 3.86735 13.0001 4.00003C13.0001 4.13272 12.9474 4.25996 12.8535 4.35378L8.70666 8.50003L12.8535 12.6463Z"
+                              fill="#210909"
+                            />
+                          </svg>
+                        </StepDelete>
+                      )}
+                    </Step>
+                  );
+                })}
+              </StepContainer>
+              <StepInputContianer>
+                <StepInput
+                  type="text"
+                  placeholder="예) 1차 면접"
+                  className="text"
+                  value={addStepValue}
+                  onChange={event => setAddStepValue(event.target.value)}
+                  onKeyDown={event => event.key === "Enter" && addStep(event)}
+                />
+                <Button type="button" className="text" onClick={addStep}>
+                  단계추가
+                </Button>
+              </StepInputContianer>
+            </InputContents>
+            <ErrorMessage>{jobPostingError}</ErrorMessage>
+          </InputContainer>
+
+          <InputContainer>
+            <TitleContainer>
+              <InputTitle>공고내용</InputTitle>
+              <Info className="text-sm">
+                **텍스트와 이미지 둘 다 작성시, 이미지는 맨 하단에 추가됩니다.
+              </Info>
+            </TitleContainer>
+            <Contents
+              placeholder="공고내용을 입력해주세요."
+              className="text"
+              {...register("jobPostingContent")}
+            />
+            <FileContainer>
+              <FileName>{fileName || ""}</FileName>
+              <FileInput type="file" id="image" onChange={uploadFile} />
+              <label htmlFor="image">이미지 업로드</label>
+            </FileContainer>
+          </InputContainer>
+          <SubmitButton type="submit" className="sub-title" />
+        </form>
       </Wrapper>
     </>
   );
 };
+
+const ErrorMessage = styled.div`
+  padding: 8px;
+  color: var(--color-red);
+`;
 
 const Title = styled.h2`
   margin-top: 120px;
@@ -292,6 +542,7 @@ const Title = styled.h2`
 const Wrapper = styled.div`
   max-width: 1200px;
   padding: 0 24px;
+  padding-bottom: 120px;
 `;
 
 const InputContainer = styled.div`
@@ -321,6 +572,11 @@ const InputText = styled.input`
   border: 0;
   border-radius: var(--button-radius);
   flex: 1;
+
+  &:disabled {
+    color: var(--bg-light-gray);
+    background-color: #f8f8f8;
+  }
 `;
 
 const InputShortText = styled(InputText)`
@@ -391,183 +647,179 @@ const TimePickerContainer = styled.div`
   position: relative;
   z-index: 2;
 
-  & {
-    .react-datepicker-popper {
-      background-color: #ffffff;
-      border: 1px solid #b7b7b7;
-      border-radius: var(--button-radius);
-      transform: translate(0px, -250px) !important;
+  .react-datepicker-popper {
+    background-color: #ffffff;
+    border: 1px solid #b7b7b7;
+    border-radius: var(--button-radius);
+    transform: translate(0px, -250px) !important;
+  }
+
+  .react-datepicker__triangle {
+    display: none;
+  }
+
+  .react-datepicker__time-list {
+    height: 250px;
+    overflow-y: scroll;
+  }
+
+  .react-datepicker__time-list-item {
+    list-style: none;
+    width: 100px;
+    padding: 8px;
+    text-align: center;
+    cursor: pointer;
+
+    &:hover {
+      color: #ffffff;
+      background-color: var(--primary-color);
     }
 
-    .react-datepicker__triangle {
-      display: none;
+    &[aria-selected="true"] {
+      color: #ffffff;
+      background-color: var(--primary-color);
     }
+  }
 
-    .react-datepicker__time-list {
-      height: 250px;
-      overflow-y: scroll;
-    }
-
-    .react-datepicker__time-list-item {
-      list-style: none;
-      width: 100px;
-      padding: 8px;
-      text-align: center;
-      cursor: pointer;
-
-      &:hover {
-        color: #ffffff;
-        background-color: var(--primary-color);
-      }
-
-      &[aria-selected="true"] {
-        color: #ffffff;
-        background-color: var(--primary-color);
-      }
-    }
-
-    .react-datepicker__aria-live {
-      display: none;
-    }
+  .react-datepicker__aria-live {
+    display: none;
   }
 `;
 
 const DatePickerContainer = styled.div`
   position: relative;
-  & {
-    .react-datepicker-popper {
-      z-index: 2;
+  .react-datepicker-popper {
+    z-index: 2;
 
-      position: relative;
-      background-color: #ffffff;
-      border: 1px solid #b7b7b7;
-      border-radius: var(--button-radius);
-    }
+    position: relative;
+    background-color: #ffffff;
+    border: 1px solid #b7b7b7;
+    border-radius: var(--button-radius);
+  }
 
-    &:nth-child(1) .react-datepicker-popper {
-      transform: translate(0, -290px) !important;
-    }
+  &:nth-child(1) .react-datepicker-popper {
+    transform: translate(0, -300px) !important;
+  }
 
-    &:nth-child(3) .react-datepicker-popper {
-      transform: translate(-137px, -300px) !important;
-    }
+  &:nth-child(3) .react-datepicker-popper {
+    transform: translate(-137px, -300px) !important;
+  }
 
-    .react-datepicker__aria-live {
+  .react-datepicker__aria-live {
+    display: none;
+  }
+
+  .react-datepicker {
+    width: 100%;
+  }
+
+  .react-datepicker__navigation {
+    position: absolute;
+    top: 8px;
+    left: 8px;
+    width: 48px;
+    height: 48px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    span {
       display: none;
     }
 
-    .react-datepicker {
-      width: 100%;
+    &::after {
+      content: "";
+      position: relative;
+      width: 24px;
+      height: 24px;
+      background: url("/img/arrow.svg") no-repeat;
+      background-size: contain;
+      background-position: center;
     }
-
-    .react-datepicker__navigation {
-      position: absolute;
-      top: 8px;
-      left: 8px;
-      width: 48px;
-      height: 48px;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-
-      span {
-        display: none;
-      }
-
-      &::after {
-        content: "";
-        position: relative;
-        width: 24px;
-        height: 24px;
-        background: url("/img/arrow.svg") no-repeat;
-        background-size: contain;
-        background-position: center;
-      }
+  }
+  .react-datepicker__navigation--previous {
+    &::after {
+      transform: rotate(180deg);
     }
-    .react-datepicker__navigation--previous {
-      &::after {
-        transform: rotate(180deg);
-      }
-    }
+  }
 
-    .react-datepicker__navigation--next {
-      left: auto;
-      right: 8px;
-    }
+  .react-datepicker__navigation--next {
+    left: auto;
+    right: 8px;
+  }
 
-    .react-datepicker__month-container {
-      padding: 8px;
-    }
+  .react-datepicker__month-container {
+    padding: 8px;
+  }
 
-    .react-datepicker__current-month {
-      text-align: center;
-      line-height: 48px;
-      font-size: 1.3rem;
-    }
+  .react-datepicker__current-month {
+    text-align: center;
+    line-height: 48px;
+    font-size: 1.3rem;
+  }
 
-    .react-datepicker__day-names {
-      display: flex;
+  .react-datepicker__day-names {
+    display: flex;
 
-      .react-datepicker__day-name {
-        flex: 1;
-        width: 2.4rem;
-        text-align: center;
-        line-height: 2rem;
-        user-select: none;
-      }
-    }
-
-    .react-datepicker__navigation {
-      position: absolute;
-    }
-
-    .react-datepicker__week {
-      display: flex;
-    }
-
-    .react-datepicker__day {
+    .react-datepicker__day-name {
+      flex: 1;
       width: 2.4rem;
       text-align: center;
-      line-height: 2.4rem;
-      cursor: pointer;
+      line-height: 2rem;
+      user-select: none;
+    }
+  }
 
-      &.react-datepicker__day--today {
-        font-weight: 700;
-      }
+  .react-datepicker__navigation {
+    position: absolute;
+  }
 
-      &:hover {
-        color: #ffffff;
-        background-color: var(--primary-color);
-      }
+  .react-datepicker__week {
+    display: flex;
+  }
 
-      &.react-datepicker__day--range {
-        background-color: var(--border-gray-100);
-      }
+  .react-datepicker__day {
+    width: 2.4rem;
+    text-align: center;
+    line-height: 2.4rem;
+    cursor: pointer;
 
-      &.react-datepicker__day--in-selecting-range {
-        color: var(--text-black);
-        background-color: #eff5ff;
-      }
-
-      &.react-datepicker__day--in-range {
-        color: var(--text-black);
-        background-color: var(--bg-light-gray);
-      }
-
-      &[aria-selected="true"] {
-        color: #ffffff;
-        background-color: var(--primary-color);
-      }
-
-      &.react-datepicker__day--in-range:not(.react-datepicker__day--in-selecting-range) {
-        color: var(--text-black);
-        background-color: var(--bg-light-blue);
-      }
+    &.react-datepicker__day--today {
+      font-weight: 700;
     }
 
-    .react-datepicker__triangle {
-      display: none;
+    &:hover {
+      color: #ffffff;
+      background-color: var(--primary-color);
     }
+
+    &.react-datepicker__day--range {
+      background-color: var(--border-gray-100);
+    }
+
+    &.react-datepicker__day--in-selecting-range {
+      color: var(--text-black);
+      background-color: #eff5ff;
+    }
+
+    &.react-datepicker__day--in-range {
+      color: var(--text-black);
+      background-color: var(--bg-light-gray);
+    }
+
+    &[aria-selected="true"] {
+      color: #ffffff;
+      background-color: var(--primary-color);
+    }
+
+    &.react-datepicker__day--in-range:not(.react-datepicker__day--in-selecting-range) {
+      color: var(--text-black);
+      background-color: var(--bg-light-blue);
+    }
+  }
+
+  .react-datepicker__triangle {
+    display: none;
   }
 `;
 
@@ -589,6 +841,7 @@ const DateInput = styled(TimeInput)`
 
 const StepContainer = styled.div`
   display: flex;
+  flex-wrap: wrap;
   gap: 8px;
 `;
 
@@ -689,6 +942,17 @@ const FileInput = styled.input`
       transform: scale(99%);
     }
   }
+`;
+
+const SubmitButton = styled.input`
+  margin-top: 100px;
+  padding: 16px;
+  width: 100%;
+  color: #ffffff;
+  border: 0;
+  border-radius: var(--button-radius);
+  background-color: var(--primary-color);
+  cursor: pointer;
 `;
 
 export default CreateJobPost;


### PR DESCRIPTION
## 작업 내용

### react-hook-form 적용

![image](https://github.com/cheonjiyun/auto-enterview-fe/assets/70828192/fe088ea0-4b41-46da-83af-9d1b05b23f8e)
전형단계는 따로 useForm에서 관리가 안된다고 판단해서, 단계만 따로 useState로 저장하였습니다.

### 유효성검사

![image](https://github.com/cheonjiyun/auto-enterview-fe/assets/70828192/a407544f-dc5b-4104-982d-06d2f8157e5e)
react-hook-form에 있는 require 와 error를 통해 유효성검사를 해주었습니다.

### 경력무관클릭시 input disable 및 기본정보 저장
경력무관 체크 -> career를 -1로 저장 및 기본값을 useRef에 저장
경력무관 해제 -> 저장되어있던 값을 career에 저장
경력입력시 -> career에 숫자 저장 및 useRef저장

로직이 엄청복잡해서 표로 그려봤습니다.
이전값을 저장하려다보니 외부에 useForm외부에 저장을 했습니다
이렇게 복잡해도 되는건가 싶네요..

![image](https://github.com/cheonjiyun/auto-enterview-fe/assets/70828192/28f2934c-db14-43a0-9698-040f62d49669)



### 전형절차 추가기능
![image](https://github.com/cheonjiyun/auto-enterview-fe/assets/70828192/d82ecf4d-6e9e-4b44-96ff-0fd3e1d0015f)

input에서 enter혹은 클릭하면 추가하도록 했습니다.
`const [jobPostingSteps, setJobPostingSteps] = useState(["서류전형"]);` 이렇게 배열로 저장해서 map으로 돌려주었습니다.
1단계는 못지우도록 했습니다.
우선 최대 10개만 가능하도록 했습니다.

### 파일 이름추출

![image](https://github.com/cheonjiyun/auto-enterview-fe/assets/70828192/23f17f7e-5244-4d80-8f63-6387f914b297)
파일이름 추출해서 넣어주었습니다.


## 스크린샷(선택)

![image](https://github.com/cheonjiyun/auto-enterview-fe/assets/70828192/719e3d42-93b3-43e0-89de-7660ea9480e2)

## 리뷰 요구사항

혹시 useRef이해가 되신다면,, 다른 방법이 있다면 알려주세욥
혹시 제가 빠뜨린 기능이 있다면 말씀해주세요.


## PS

api연동은 아직 하지 않았습니다. 이것도 다음 pr에 하겠습니다.


## 연관된 이슈

close #28 
