### PR TITLE
계정정보,탈퇴하기/#29

### DIFF
--- a/src/components/routes/Account.tsx
+++ b/src/components/routes/Account.tsx
@@ -116,7 +116,7 @@ const Account: React.FC<AccountProps> = ({ role }) => {
           {role === "company" && (
           <Input type="text" name="companyName" placeholder="회사명"/> )}
           <Button type="submit">비밀번호 변경</Button>
-          <Button type="button" onClick={handleDeleteAccount}>회원 탈퇴</Button>
+          <Button className="out" type="button" onClick={handleDeleteAccount}>회원 탈퇴</Button>
       </Form>
     </Container>
   </Wrapper>
@@ -215,6 +215,11 @@ const Button = styled.button`
   text-transform: uppercase;
   transition: transform 80ms ease-in;
   width: 100%;
+  &.out{
+  border: 1px solid #ff0000;
+  background-color: #ffffff;
+  color: #ff0000;
+  }
   `
 
 const MessageSpan = styled.span`

--- a/src/components/routes/Account.tsx
+++ b/src/components/routes/Account.tsx
@@ -1,6 +1,7 @@
 import styled, { keyframes } from 'styled-components';
 import { FaRegEye, FaRegEyeSlash } from "react-icons/fa";
 import { useState } from 'react';
+import axios from 'axios';
 
 interface AccountProps {
   role: string;
@@ -8,9 +9,42 @@ interface AccountProps {
 
 const Account: React.FC<AccountProps> = ({ role }) => {
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
+  const [oldPassword, setOldPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [message, setMessage] = useState('');
+  const [confirmMessage, setConfirmMessage] = useState('');
 
 const togglePasswordVisibility = () => {
     setIsPasswordVisible(!isPasswordVisible);
+  };
+const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+
+    // 새로운 비밀번호 확인
+    if (newPassword !== confirmPassword) {
+      setConfirmMessage('일치하지 않는 비밀번호입니다');
+      return;
+    } else {
+      setConfirmMessage('일치하는 비밀번호입니다');
+    }
+    
+    try {
+      // 기존 비밀번호 확인 요청
+      const response = await axios.post('https://api.example.com/check-password', {
+        password: oldPassword,
+      });
+
+      if (response.data.success) {
+        setMessage('일치하는 비밀번호입니다');
+        // 비밀번호 변경 로직 추가
+      } else {
+        setMessage('일치하지않는 비밀번호입니다');
+      }
+    } catch (error) {
+      console.error('Error checking password:', error);
+      setMessage('일치하지않는 비밀번호입니다');
+    }
   };
 
 
@@ -18,23 +52,26 @@ const togglePasswordVisibility = () => {
   return(
   <Wrapper>
     <Container id="container">
-      <Form>
+      <Form onSubmit={handleSubmit}>
         <H1>비밀번호 변경</H1>
         <Span>비밀번호를 변경해주세요.</Span>
         <PassWordCheck>
-          <Input type={isPasswordVisible ? "text" : "password"} placeholder="기존 비밀번호"/>
+          <Input type={isPasswordVisible ? "text" : "password"} placeholder="기존 비밀번호" value={oldPassword} onChange={(e) => setOldPassword(e.target.value)}/>
           <Icon onClick={togglePasswordVisibility}>{isPasswordVisible ? <FaRegEye /> : <FaRegEyeSlash />}</Icon>
           </PassWordCheck>
+          <MessageSpan>{message}</MessageSpan>
           <PassWordCheck>
-          <Input type={isPasswordVisible ? "text" : "password"} placeholder="새로운 비밀번호"/>
+          <Input type={isPasswordVisible ? "text" : "password"} placeholder="새로운 비밀번호" value={newPassword} onChange={(e) => setNewPassword(e.target.value)} />
           <Icon onClick={togglePasswordVisibility}>{isPasswordVisible ? <FaRegEye /> : <FaRegEyeSlash />}</Icon>
           </PassWordCheck>
+          <MessageSpan>{message}</MessageSpan>
           <PassWordCheck>
-          <Input type={isPasswordVisible ? "text" : "password"} placeholder="새로운 비밀번호 한번 더"/>
+          <Input type={isPasswordVisible ? "text" : "password"} placeholder="새로운 비밀번호 한번 더" value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} />
           <Icon onClick={togglePasswordVisibility}>{isPasswordVisible ? <FaRegEye /> : <FaRegEyeSlash />}</Icon>
           </PassWordCheck>
           {role === "company" && (
           <Input type="text" name="companyName" placeholder="회사명"/> )}
+          <MessageSpan>{message}</MessageSpan>
           <Button type="submit">비밀번호 변경</Button>
           <Button type="submit">회원 탈퇴</Button>
       </Form>
@@ -137,6 +174,11 @@ const Button = styled.button`
   width: 100%;
   `
 
+const MessageSpan = styled.span`
+  color: red;
+  margin-top: 1px;
+  font-size: 14px;
+`;
 
 
 

--- a/src/components/routes/Account.tsx
+++ b/src/components/routes/Account.tsx
@@ -2,7 +2,11 @@ import styled, { keyframes } from 'styled-components';
 import { FaRegEye, FaRegEyeSlash } from "react-icons/fa";
 import { useState } from 'react';
 
-const Account = () => {
+interface AccountProps {
+  role: string;
+}
+
+const Account: React.FC<AccountProps> = ({ role }) => {
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
 
 const togglePasswordVisibility = () => {
@@ -29,7 +33,8 @@ const togglePasswordVisibility = () => {
           <Input type={isPasswordVisible ? "text" : "password"} placeholder="새로운 비밀번호 한번 더"/>
           <Icon onClick={togglePasswordVisibility}>{isPasswordVisible ? <FaRegEye /> : <FaRegEyeSlash />}</Icon>
           </PassWordCheck>
-          <Input type="text" name="companyName" placeholder="회사명"/>
+          {role === "company" && (
+          <Input type="text" name="companyName" placeholder="회사명"/> )}
           <Button type="submit">비밀번호 변경</Button>
           <Button type="submit">회원 탈퇴</Button>
       </Form>

--- a/src/components/routes/Account.tsx
+++ b/src/components/routes/Account.tsx
@@ -28,7 +28,7 @@ const handleSubmit = async (event: React.FormEvent) => {
     } else {
       setConfirmMessage('일치하는 비밀번호입니다');
     }
-    
+
     try {
       // 기존 비밀번호 확인 요청
       const response = await axios.post('https://api.example.com/check-password', {
@@ -64,14 +64,13 @@ const handleSubmit = async (event: React.FormEvent) => {
           <Input type={isPasswordVisible ? "text" : "password"} placeholder="새로운 비밀번호" value={newPassword} onChange={(e) => setNewPassword(e.target.value)} />
           <Icon onClick={togglePasswordVisibility}>{isPasswordVisible ? <FaRegEye /> : <FaRegEyeSlash />}</Icon>
           </PassWordCheck>
-          <MessageSpan>{message}</MessageSpan>
           <PassWordCheck>
           <Input type={isPasswordVisible ? "text" : "password"} placeholder="새로운 비밀번호 한번 더" value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} />
           <Icon onClick={togglePasswordVisibility}>{isPasswordVisible ? <FaRegEye /> : <FaRegEyeSlash />}</Icon>
           </PassWordCheck>
           {role === "company" && (
           <Input type="text" name="companyName" placeholder="회사명"/> )}
-          <MessageSpan>{message}</MessageSpan>
+          <MessageSpan>{confirmMessage}</MessageSpan>
           <Button type="submit">비밀번호 변경</Button>
           <Button type="submit">회원 탈퇴</Button>
       </Form>

--- a/src/components/routes/Account.tsx
+++ b/src/components/routes/Account.tsx
@@ -1,5 +1,138 @@
+import styled, { keyframes } from 'styled-components';
+import { FaRegEye, FaRegEyeSlash } from "react-icons/fa";
+import { useState } from 'react';
+
 const Account = () => {
-  return <></>;
+  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
+
+const togglePasswordVisibility = () => {
+    setIsPasswordVisible(!isPasswordVisible);
+  };
+
+
+
+  return(
+  <Wrapper>
+    <Container id="container">
+      <Form>
+        <H1>비밀번호 변경</H1>
+        <Span>비밀번호를 변경해주세요.</Span>
+        <PassWordCheck>
+          <Input type={isPasswordVisible ? "text" : "password"} placeholder="기존 비밀번호"/>
+          <Icon onClick={togglePasswordVisibility}>{isPasswordVisible ? <FaRegEye /> : <FaRegEyeSlash />}</Icon>
+          </PassWordCheck>
+          <PassWordCheck>
+          <Input type={isPasswordVisible ? "text" : "password"} placeholder="새로운 비밀번호"/>
+          <Icon onClick={togglePasswordVisibility}>{isPasswordVisible ? <FaRegEye /> : <FaRegEyeSlash />}</Icon>
+          </PassWordCheck>
+          <PassWordCheck>
+          <Input type={isPasswordVisible ? "text" : "password"} placeholder="새로운 비밀번호 한번 더"/>
+          <Icon onClick={togglePasswordVisibility}>{isPasswordVisible ? <FaRegEye /> : <FaRegEyeSlash />}</Icon>
+          </PassWordCheck>
+          <Input type="text" name="companyName" placeholder="회사명"/>
+          <Button type="submit">비밀번호 변경</Button>
+          <Button type="submit">회원 탈퇴</Button>
+      </Form>
+    </Container>
+  </Wrapper>
+  );
 };
+
+
+
+// 비밀번호 변경 style
+const show = keyframes`
+  0%, 49.99% {
+    opacity: 0;
+    z-index: 1;
+  }
+
+  50%, 100% {
+    opacity: 1;
+    z-index: 5;
+  }
+`;
+
+const Wrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 55px;
+`
+
+const Container = styled.div`
+  background-color: #fff;
+  border-radius: 10px;
+  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.25), 0 10px 10px rgba(0, 0, 0, 0.22);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  overflow: hidden;
+  width: 600px;
+  max-width: 100%;
+  min-height: 550px;
+`
+
+const Form = styled.form`
+  background-color: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  padding: 0 50px;
+  height: 100%;
+  text-align: center;
+`
+
+const H1 = styled.h1`
+  font-weight: bold;
+  margin-bottom: 12px;
+`
+
+const Span = styled.span`
+  font-size: 12px;
+  margin-top: 5px;
+  margin-bottom: 5px;
+`
+
+const Input = styled.input`
+  background-color: #eee;
+  border: none;
+  padding: 15px 55px;
+  margin: 10px 0;
+  width: 100%;
+`
+
+const PassWordCheck = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+`
+
+const Icon = styled.div`
+  cursor: pointer;
+  margin-left: -30px;
+  display: flex;
+  align-items: center;
+`;
+
+const Button = styled.button`
+  border-radius: 20px;
+  border: 1px solid #000694;
+  background-color: #000694;
+  margin-top: 20px;
+  color: #ffffff;
+  font-size: 12px;
+  font-weight: bold;
+  padding: 12px 45px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  transition: transform 80ms ease-in;
+  width: 100%;
+  `
+
+
+
 
 export default Account;

--- a/src/components/routes/Account.tsx
+++ b/src/components/routes/Account.tsx
@@ -1,6 +1,7 @@
 import styled, { keyframes } from 'styled-components';
 import { FaRegEye, FaRegEyeSlash } from "react-icons/fa";
 import { useState, FormEvent, ChangeEvent } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
 import axios from 'axios';
 
 interface AccountProps {
@@ -82,6 +83,12 @@ const Account: React.FC<AccountProps> = ({ role }) => {
     return regex.test(password);
   };
 
+  const handleDeleteAccount = () => {
+    if (window.confirm("정말 탈퇴하시겠습니까?")) {
+      alert("탈퇴되었습니다");
+      window.location.href = "/"; // 메인 화면으로 이동
+    }
+  };
 
 
   return(
@@ -109,7 +116,7 @@ const Account: React.FC<AccountProps> = ({ role }) => {
           {role === "company" && (
           <Input type="text" name="companyName" placeholder="회사명"/> )}
           <Button type="submit">비밀번호 변경</Button>
-          <Button type="submit">회원 탈퇴</Button>
+          <Button type="button" onClick={handleDeleteAccount}>회원 탈퇴</Button>
       </Form>
     </Container>
   </Wrapper>

--- a/src/components/routes/Login.tsx
+++ b/src/components/routes/Login.tsx
@@ -1,4 +1,4 @@
-import { useState, FormEvent } from 'react';
+import { useState, FormEvent, ChangeEvent } from 'react';
 import styled, { keyframes } from 'styled-components';
 import { FaRegEye, FaRegEyeSlash } from "react-icons/fa";
 import { Link } from 'react-router-dom'; 
@@ -8,6 +8,7 @@ const Login = () => {
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [passwordError, setPasswordError] = useState("");
 
 const togglePasswordVisibility = () => {
     setIsPasswordVisible(!isPasswordVisible);
@@ -19,6 +20,14 @@ const handleSubmit = (e: FormEvent) => {
       alert("정보를 입력하지 않았습니다");
       return;
     }
+
+    // 비밀번호 유효성 검사
+    const isValidPassword = validatePassword(password);
+    if (!isValidPassword) {
+      setPasswordError("8-16자리 영문 대 소문자, 숫자, 특수문자를 포함해야 합니다.");
+      return;
+    }
+
     try {
       // 서버 API 호출
       //const response = await axios.post('https://api.example.com/login', {
@@ -39,6 +48,13 @@ const handleSubmit = (e: FormEvent) => {
     console.log("로그인 시도:", { email, password });
   };
 
+// 비밀번호 유효성 검사 로직 추가
+  const validatePassword = (password: string) => {
+    const regex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,16}$/;
+    return regex.test(password);
+  };
+
+
 // 로그인 JSX
   return (
   <Wrapper>
@@ -49,9 +65,10 @@ const handleSubmit = (e: FormEvent) => {
           <Span>이메일과 비밀번호를 입력해주세요.</Span>
           <Input type="email" placeholder="이메일" value={email} onChange={(e) => setEmail(e.target.value)} />
           <PassWordCheck>
-          <Input type={isPasswordVisible ? "text" : "password"} placeholder="비밀번호" value={password} onChange={(e) => setPassword(e.target.value)}/>
+          <Input type={isPasswordVisible ? "text" : "password"} placeholder="비밀번호" onChange={(e: ChangeEvent<HTMLInputElement>) => setPassword(e.target.value)}/>
           <Icon onClick={togglePasswordVisibility}>{isPasswordVisible ? <FaRegEye /> : <FaRegEyeSlash />}</Icon>
           </PassWordCheck>
+          <ErrorSpan>{passwordError}</ErrorSpan>
           <Button type="submit">로그인</Button>
           <FindLink to="/find-email">
           <FindEmailButton>이메일 찾기</FindEmailButton>
@@ -175,5 +192,12 @@ const Icon = styled.div`
 const FindLink= styled(Link)`
   width: 100%;
 `
+
+const ErrorSpan = styled.span`
+  color: red;
+  font-size: 12px;
+  margin-top: 5px;
+`;
+
 
 export default Login;

--- a/src/components/routes/SignUp.tsx
+++ b/src/components/routes/SignUp.tsx
@@ -6,6 +6,7 @@ import { FaRegEye, FaRegEyeSlash } from "react-icons/fa";
 const SignUp: React.FC = () => {
   const [isRightPanelActive, setIsRightPanelActive] = useState(false);
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
+  const [passwordError, setPasswordError] = useState('');
   const [formData, setFormData] = useState({
     companyEmail: '',
     companyEmailNumber: '',
@@ -18,7 +19,6 @@ const SignUp: React.FC = () => {
     userPassword: '',
     userPhoneNumber: ''
   });
-
 
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
@@ -89,6 +89,23 @@ const togglePasswordVisibility = () => {
     setIsPasswordVisible(!isPasswordVisible);
   };
 
+// 비밀번호 유효성 검사 로직 추가
+const validatePassword = (password: string) => {
+    const regex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,16}$/;
+    return regex.test(password);
+  };
+
+const handlePasswordChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.target;
+    if (validatePassword(value)) {
+      setPasswordError('');
+    } else {
+      setPasswordError('8-16자리 영문 대 소문자, 숫자, 특수문자를 포함해야 합니다');
+    }
+    setFormData({ ...formData, [e.target.name]: value });
+  };
+
+
 // 회원가입 JSX
   return (
     <Wrapper>
@@ -103,9 +120,10 @@ const togglePasswordVisibility = () => {
           </EmailCheck>
           <Input type="text" name="companyEmailNumber" placeholder="이메일 인증번호" value={formData.companyEmailNumber} onChange={handleInputChange} />
           <PassWordCheck>
-          <Input type={isPasswordVisible ? "text" : "password"}  name="companyPassword" placeholder="비밀번호" value={formData.companyPassword} onChange={handleInputChange} />
+          <Input type={isPasswordVisible ? "text" : "password"}  name="companyPassword" placeholder="비밀번호" value={formData.companyPassword} onChange={handlePasswordChange} />
           <Icon onClick={togglePasswordVisibility}>{isPasswordVisible ? <FaRegEye /> : <FaRegEyeSlash />}</Icon>
           </PassWordCheck>
+          <ErrorSpan>{passwordError}</ErrorSpan>
           <Input type="text" name="companyName" placeholder="회사명" value={formData.companyName} onChange={handleInputChange} />
           <Input type="text" name="companyPhoneNumber" placeholder="회사 전화번호 ( - 사용)" value={formData.companyPhoneNumber} onChange={handleInputChange} />
           <Button type="submit">회사 등록하기</Button>
@@ -122,9 +140,10 @@ const togglePasswordVisibility = () => {
           </EmailCheck>
           <Input type="text" name="userEmailNumber" placeholder="이메일 인증번호" value={formData.userEmailNumber} onChange={handleInputChange} />
           <PassWordCheck>
-          <Input type={isPasswordVisible ? "text" : "password"}  name="userPassword" placeholder="비밀번호" value={formData.userPassword} onChange={handleInputChange} />
+          <Input type={isPasswordVisible ? "text" : "password"}  name="userPassword" placeholder="비밀번호" value={formData.userPassword} onChange={handlePasswordChange} />
           <Icon onClick={togglePasswordVisibility}>{isPasswordVisible ? <FaRegEye /> : <FaRegEyeSlash />}</Icon>
           </PassWordCheck>
+          <ErrorSpan>{passwordError}</ErrorSpan>
           <Input type="text" name="userPhoneNumber" placeholder="핸드폰 번호 ( - 사용)" value={formData.userPhoneNumber} onChange={handleInputChange} />
           <Button type="submit">회원가입</Button>
         </Form>
@@ -178,9 +197,9 @@ const Container = styled.div`
   align-items: center;
   position: relative;
   overflow: hidden;
-  width: 768px;
+  width: 800px;
   max-width: 100%;
-  min-height: 480px;
+  min-height: 530px;
   &.right-panel-active .user-sign-up {
     transform: translateX(100%);
   }
@@ -287,7 +306,7 @@ const Button = styled.button`
     padding: 0px;
     border-radius: 0px;
     font-size: 10px;
-    margin-top: 5px;
+    margin-top: 7px;
   }
   &:active {
     transform: scale(0.95);
@@ -316,7 +335,7 @@ const Input = styled.input`
   background-color: #eee;
   border: none;
   padding: 15px 15px;
-  margin: 5px 0;
+  margin: 7px 0;
   width: 100%;
 `;
 
@@ -354,6 +373,12 @@ const Icon = styled.div`
   margin-left: -30px;
   display: flex;
   align-items: center;
+`;
+
+const ErrorSpan = styled.span`
+  color: red;
+  margin-top: 5px;
+  font-size: 12px;
 `;
 
 export default SignUp;


### PR DESCRIPTION
## 작업 내용

1. 비밀번호 변경 폼, style 적용
2. 회사명 Input 권한 -> 회사 Role 권한이 있는 사람만 보이게 구현
3. 기존 비밀번호가 일치하면 "일치하는 비밀번호입니다" 라는 문구, 기존 비밀번호가 일치하지 않으면 "일치하지않는 비밀번호입니다"
4. 응답에 따라 message 상태를 업데이트하여 일치 여부를 표시
5. 기존 비밀번호가 서버 API와 일치하는지 확인하고 메시지를 표시합니다.
6. 새로운 비밀번호와 확인 비밀번호가 일치하는지 확인하고 메시지를 표시합니다.
7. [회원가입, 로그인, 비밀번호변경]비밀번호 유효성 검사 로직 추가 (8-16자리 영문 대 소문자, 숫자, 특수문자 포함)
8. 비밀번호에 따라 message 상태를 업데이트하여 일치 여부와 유효성 검사 문구 응답에 따라 문구 변경
9. 회원탈퇴버튼 ->  alert “정말 탈퇴하시겠습니까?” ->"취소-> 페이지 그대로 / "확인" -> alert “탈퇴되었습니다.” -> 메인

## 스크린샷(선택)
1. ![KakaoTalk_20240704_143338258](https://github.com/cheonjiyun/auto-enterview-fe/assets/138658065/11001e30-f15b-4011-9b8d-3e4f80f07dd6)
- 회사명까지 있는 폼

 2. ![KakaoTalk_20240704_152154175](https://github.com/cheonjiyun/auto-enterview-fe/assets/138658065/c7718b38-1967-4193-b750-c8c2c3f2b362)
- 회사 Role 권한 부여받은 사람만 보이게 해놈

3. ![KakaoTalk_20240704_170805597](https://github.com/cheonjiyun/auto-enterview-fe/assets/138658065/e552ea13-dde7-48c0-9ec0-4cb17082a31c)
- 비밀번호 변경/ 비밀번호 유효성 검사 기능구현

4.![KakaoTalk_20240704_180248350](https://github.com/cheonjiyun/auto-enterview-fe/assets/138658065/e88a6792-369e-4730-88c2-130d409ff486)
-  API 없어서 "기존 비밀번호 확인 중 오류", "기존 비밀번호와 일치합니다", "기본 비밀번호와 일치하지않습니다" 문구 기능구
- 새로운 비밀번호, 확인 비밀번호 일치, 불일치 문구 기능구현

5.  ![KakaoTalk_20240704_162408805](https://github.com/cheonjiyun/auto-enterview-fe/assets/138658065/37178680-1f2a-4350-8960-b58e45f7dd77)
- 회원가입/ 개인,회사 비밀번호 유효성 기능 추가

6. ![KakaoTalk_20240704_164526125](https://github.com/cheonjiyun/auto-enterview-fe/assets/138658065/b5d2795a-b869-4457-8e92-3193682c48b8)
- 로그인/ 비밀번호 유효성 기능 추가


## 리뷰 요구사항
- API 연동은 다시 PR올리겠습니다~
- 혹시 더 필요한 기능이 있을까요?

## 연관된 이슈

close #29
