### PR TITLE
RecruitBoard 마크업 및 로직 구현

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -68,7 +68,7 @@ const router = createBrowserRouter([
         ),
       },
       {
-        path: "/view-resume/:userId",
+        path: "/view-resume/:candidateKey",
         element: (
           <ProtectedRoute>
             <ViewResume />
@@ -84,7 +84,8 @@ const router = createBrowserRouter([
         ),
       },
       {
-        path: "/recruit-board/:recruitId",
+        // path: "/recruit-board/:recruitId",
+        path: "/recruit-board",
         element: (
           <ProtectedRoute>
             <RecruitBoard />

--- a/src/components/css/Common.ts
+++ b/src/components/css/Common.ts
@@ -1,0 +1,38 @@
+import styled from "styled-components";
+
+export const Wrapper = styled.div`
+  padding: 100px 0;
+`;
+
+export const Inner = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 60px;
+`;
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+`;
+
+export const UserName = styled.h2`
+  font-size: 1.5rem;
+  font-weight: 700;
+`;
+
+export const SubTitle = styled.h3`
+  font-size: 1.3rem;
+  font-weight: 700;
+`;
+
+export const FullBtn = styled.button`
+  z-index: 2;
+  position: relative;
+  width: 100%;
+  padding: 8px 0;
+  border-radius: var(--button-radius);
+  background-color: var(--primary-color);
+  font: inherit;
+  color: #fff;
+`;

--- a/src/components/routes/CompanyMypage.tsx
+++ b/src/components/routes/CompanyMypage.tsx
@@ -6,14 +6,9 @@ import { HiOutlinePlus } from "react-icons/hi2";
 import { IoMdClose } from "react-icons/io";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
+import { Container, Inner, SubTitle, UserName, Wrapper } from "../css/Common";
 
-const infoTitles = [
-  "대표자",
-  "설립년도",
-  "주소",
-  "사원수",
-  "회사 홈페이지 URL",
-];
+const infoTitles = ["대표자", "설립년도", "주소", "사원수", "회사 홈페이지 URL"];
 
 const infoTypes = ["text", "date", "text", "number", "text"];
 
@@ -60,7 +55,7 @@ const CompanyMypage = () => {
   };
 
   const cancelEdit = () => {
-    setEditMode((edit) => !edit);
+    setEditMode(edit => !edit);
   };
 
   const saveInfo = async () => {
@@ -71,7 +66,7 @@ const CompanyMypage = () => {
       boss: bossValue,
       address: addressValue,
     };
-    const bodyFill = Object.values(body).every((v) => v.trim());
+    const bodyFill = Object.values(body).every(v => v.trim());
 
     if (bodyFill) {
       try {
@@ -80,7 +75,7 @@ const CompanyMypage = () => {
         } else {
           await axios.post(`${infoURL}`, body);
         }
-        setEditMode((edit) => !edit);
+        setEditMode(edit => !edit);
       } catch (error) {
         alert("회원 정보를 저장하는데 문제가 발생했습니다. 다시 시도해주세요.");
       }
@@ -90,17 +85,17 @@ const CompanyMypage = () => {
   };
 
   const editInfo = () => {
-    setEditMode((edit) => !edit);
+    setEditMode(edit => !edit);
     firstInputRef.current?.focus();
   };
 
   return (
     <Wrapper>
       <Inner className="inner-1200">
-        <UserName className="title">{"(주)회사 이름"}</UserName>
+        <UserName>{"(주)회사 이름"}</UserName>
         <Container>
           <Top>
-            <SubTitle className="sub-title">회사 정보</SubTitle>
+            <SubTitle>회사 정보</SubTitle>
             <Buttons>
               {editMode ? (
                 <>
@@ -156,7 +151,7 @@ const CompanyMypage = () => {
                     )}
                   </Info>
                 ))
-              : infoTitles.map((info) => (
+              : infoTitles.map(info => (
                   <Info className="text" key={info}>
                     <InfoTitle>{info}</InfoTitle>
                     <InfoDesc>{info}</InfoDesc>
@@ -178,9 +173,7 @@ const CompanyMypage = () => {
                 <Dday>{"D-3"}</Dday>
               </LabelWrap>
               <ListTitle>
-                {
-                  "제목입니다ㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏ"
-                }
+                {"제목입니다ㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏ"}
               </ListTitle>
               <ListCareer>{"경력"}</ListCareer>
               <ListStep>{"서류 접수중"}</ListStep>
@@ -191,9 +184,7 @@ const CompanyMypage = () => {
                 <Dday>{"D-3"}</Dday>
               </LabelWrap>
               <ListTitle>
-                {
-                  "제목입니다ㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏ"
-                }
+                {"제목입니다ㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏ"}
               </ListTitle>
               <ListCareer>{"경력"}</ListCareer>
               <ListStep>{"서류 접수중"}</ListStep>
@@ -205,25 +196,10 @@ const CompanyMypage = () => {
   );
 };
 
-const Wrapper = styled.div`
-  padding-top: 120px;
-`;
-
-const Inner = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 60px;
-`;
-
-const UserName = styled.h2``;
-
-const Container = styled.div``;
-
 const Top = styled.div`
   display: flex;
   align-items: center;
   gap: 1rem;
-  margin-bottom: 24px;
 `;
 
 const Buttons = styled.div`
@@ -295,8 +271,6 @@ const InfoInput = styled.input`
 const InfoDesc = styled.p`
   width: calc(100% - 150px);
 `;
-
-const SubTitle = styled.h3``;
 
 const CreatePost = styled(Link)`
   display: flex;

--- a/src/components/routes/RecruitBoard.tsx
+++ b/src/components/routes/RecruitBoard.tsx
@@ -168,6 +168,10 @@ const Board = styled.div`
 const Steps = styled.ol`
   display: flex;
   gap: 1rem;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 `;
 
 const Step = styled.li`

--- a/src/components/routes/RecruitBoard.tsx
+++ b/src/components/routes/RecruitBoard.tsx
@@ -1,5 +1,289 @@
+import styled from "styled-components";
+import { Container, FullBtn, Inner, SubTitle, UserName, Wrapper } from "../css/Common";
+import { useEffect, useRef, useState } from "react";
+import axios from "axios";
+import { useNavigate } from "react-router-dom";
+import { FaEnvelopeOpenText } from "react-icons/fa";
+
+interface ICandidateList {
+  candidateKey: string;
+  candidateName: string;
+  createdAt: string;
+}
+
 const RecruitBoard = () => {
-  return <></>;
+  const [steps, setSteps] = useState(["서류전형"]);
+  const [candidateList, setCandidateList] = useState<ICandidateList[]>([
+    {
+      candidateKey: "지원자 key",
+      candidateName: "지원자 이름",
+      createdAt: "지원 일자",
+    },
+  ]);
+  const [schedule, setSchedule] = useState(false);
+  const [activeList, setActiveList] = useState<string[]>([]);
+  const navigate = useNavigate();
+  const containerRef = useRef<HTMLDivElement>(null);
+  /* todo: 서류단계 통과한 지원자들 불러오기, jsx에도 적용 */
+  /* todo: 일정생성, 메일발송 이벤트 구현 */
+
+  useEffect(() => {
+    async () => {
+      try {
+        const steps = await axios.get(`/companies/${companyKey}/${jobPostingKey}/job-posting-step`);
+        setSteps(steps.data);
+
+        const candidate = await axios.get(
+          `/companies/${companyKey}/${jobPostingKey}/candidate-list`,
+        );
+        setCandidateList(candidate.data);
+      } catch (error) {
+        alert("채용단계를 불러오는데 문제가 생겼습니다. 다시 시도해주세요.");
+      }
+    };
+  }, []);
+
+  let isDragging = false;
+  let startX = 0;
+  let scrollLeft = 0;
+
+  const handleMouseDown = (e: React.MouseEvent) => {
+    isDragging = true;
+    startX = e.pageX - (containerRef.current?.offsetLeft || 0);
+    scrollLeft = containerRef.current?.scrollLeft || 0;
+  };
+
+  const handleMouseLeave = () => {
+    isDragging = false;
+  };
+
+  const handleMouseUp = () => {
+    isDragging = false;
+  };
+
+  const handleMouseMove = (e: React.MouseEvent) => {
+    if (!isDragging) return;
+    e.preventDefault();
+    const x = e.pageX - (containerRef.current?.offsetLeft || 0);
+    const walk = x - startX;
+    if (containerRef.current) {
+      containerRef.current.scrollLeft = scrollLeft - walk;
+    }
+  };
+
+  const handleOpenResume = (key: string) => {
+    navigate(`/view-resume/${key}`);
+  };
+
+  const handleClickList = (stepKey: string) => {
+    setActiveList(prevActiveList => {
+      if (prevActiveList.length === 0) {
+        return [stepKey];
+      }
+      //동일한 step의 지원자를 클릭했는지 검사
+      if (prevActiveList[0].split("/")[0] === stepKey.split("/")[0]) {
+        return prevActiveList.includes(stepKey)
+          ? prevActiveList.filter(item => item !== stepKey)
+          : [...prevActiveList, stepKey];
+      }
+
+      const ok = confirm(
+        "현재 다른 단계에서 선택중인 지원자가 있습니다. 클릭하신 단계의 지원자를 선택하시겠어요?",
+      );
+
+      if (ok) {
+        return [stepKey];
+      }
+      return prevActiveList;
+    });
+  };
+
+  return (
+    <Wrapper>
+      <Inner className="inner-1200">
+        <UserName>{"(주)회사 이름"}</UserName>
+        <Container>
+          <SubTitle>{"[FE] 신입사원 채용"}</SubTitle>
+          <Board
+            ref={containerRef}
+            onMouseDown={handleMouseDown}
+            onMouseLeave={handleMouseLeave}
+            onMouseUp={handleMouseUp}
+            onMouseMove={handleMouseMove}
+          >
+            <Steps>
+              {steps.map(step => (
+                <Step key={step}>
+                  <StepTitle className="sub-title">{step}</StepTitle>
+                  {step === "서류전형" ? null : schedule ? (
+                    <EmailBtn>예약 메일 발송하기</EmailBtn>
+                  ) : (
+                    <ScheduleBtn>일정 생성하기</ScheduleBtn>
+                  )}
+                  <Lists>
+                    {candidateList.map(candidate => (
+                      <List
+                        key={candidate.candidateKey}
+                        $isActive={activeList.includes(`${step}/${candidate.candidateKey}`)}
+                        onClick={() => handleClickList(`${step}/${candidate.candidateKey}`)}
+                      >
+                        <Name>{candidate.candidateName}</Name>
+                        <Skills>
+                          <Skill>{"Java"}</Skill>
+                          <Skill>{"React"}</Skill>
+                          <Skill>{"Typescript"}</Skill>
+                        </Skills>
+                        <View
+                          onClick={e => {
+                            e.stopPropagation();
+                            handleOpenResume(candidate.candidateKey);
+                          }}
+                        >
+                          <FaEnvelopeOpenText /> 이력서 보기
+                        </View>
+                      </List>
+                    ))}
+                  </Lists>
+                  {activeList.length && activeList[0].split("/").includes(`${step}`) ? (
+                    <PassBtn>다음 단계로 넘기기</PassBtn>
+                  ) : null}
+                </Step>
+              ))}
+            </Steps>
+          </Board>
+        </Container>
+      </Inner>
+    </Wrapper>
+  );
 };
+
+const Board = styled.div`
+  overflow: hidden;
+  padding: 1rem;
+  border-top: 3px solid var(--border-gray-200);
+  border-radius: var(--box-radius);
+  box-shadow: var(--box-shadow);
+`;
+
+const Steps = styled.ol`
+  display: flex;
+  gap: 1rem;
+`;
+
+const Step = styled.li`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  width: 25%;
+  min-width: 20%;
+  height: 70vh;
+  padding: 16px 8px;
+  border-radius: var(--box-radius);
+  background-color: var(--bg-light-gray);
+
+  &::before,
+  &::after {
+    z-index: 1;
+    content: "";
+    position: absolute;
+    bottom: 64px;
+    left: 0%;
+    width: 100%;
+    pointer-events: none;
+  }
+  &::before {
+    top: 36px;
+    height: 20px;
+    background: linear-gradient(to bottom, var(--bg-light-gray), transparent);
+  }
+  &::after {
+    bottom: 16px;
+    height: 60px;
+    background: linear-gradient(to top, var(--bg-light-gray) 50%, transparent);
+  }
+`;
+
+const StepTitle = styled.h3`
+  padding-left: 10px;
+`;
+
+const EmailBtn = styled(FullBtn)`
+  margin-top: 16px;
+  background-color: var(--sub-color);
+`;
+
+const ScheduleBtn = styled(FullBtn)`
+  margin-top: 16px;
+`;
+
+const Lists = styled.ul`
+  overflow-y: auto;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px 0 50px;
+  height: 100%;
+
+  &::-webkit-scrollbar {
+    display: none; /* Chrome , Safari , Opera */
+  }
+`;
+
+const List = styled.li<{ $isActive: boolean }>`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 8px;
+  height: 120px;
+  padding: 1rem;
+  border-radius: var(--box-radius);
+  border: 1px solid ${props => (props.$isActive ? "#000694" : "transparent")};
+  background-color: #fff;
+  box-shadow: var(--box-shadow);
+  cursor: pointer;
+`;
+
+const PassBtn = styled(FullBtn)`
+  position: absolute;
+  bottom: 10px;
+  left: 0;
+  right: 0;
+  width: 90%;
+  margin: 0 auto;
+`;
+
+const Name = styled.p`
+  font-weight: 700;
+`;
+
+const Skills = styled.div`
+  overflow: hidden;
+  display: flex;
+  gap: 5px;
+  position: relative;
+  width: 100%;
+
+  &::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 32px;
+    height: 100%;
+    background: linear-gradient(to left, #fff, transparent);
+  }
+`;
+
+const Skill = styled.p`
+  padding: 4px 8px;
+  background-color: rgba(197, 255, 197, 0.5);
+  border-radius: var(--button-radius);
+`;
+
+const View = styled.button`
+  font: inherit;
+`;
 
 export default RecruitBoard;


### PR DESCRIPTION
## 작업 내용
1.  RecruitBoard 마크업
![image](https://github.com/cheonjiyun/auto-enterview-fe/assets/141378574/821da802-af41-4346-94fe-44b1985147da)

2. [이력서보기] 클릭시, 지원자key에 맞는 이력서 페이지로 이동
![image](https://github.com/cheonjiyun/auto-enterview-fe/assets/141378574/816e5212-05be-411c-8634-fc9229c8667e)

3. 지원자 클릭시, [다음 단계로 넘기기]버튼 활성화
![image](https://github.com/cheonjiyun/auto-enterview-fe/assets/141378574/5e57794e-5a78-40ef-828b-95dab726c505)

4. 저장된 일정 정보가 있는 단계에서는 [메일 발송] 버튼으로 변경
![image](https://github.com/cheonjiyun/auto-enterview-fe/assets/141378574/13ee4361-f0ae-4ffd-8abf-f32aec675d6a)
![image](https://github.com/cheonjiyun/auto-enterview-fe/assets/141378574/2d4e05be-735f-49ed-8f48-b7aaca8fe88f)

5. 스크롤시 위아래 그라디언트로 경계선 없앰
![image](https://github.com/cheonjiyun/auto-enterview-fe/assets/141378574/a6a44154-95f8-45b8-91a7-5915c2f2d42c)

6. 1200 이너를 벗어나면 양쪽으로 드래그 가능
![recruit-board _drag](https://github.com/cheonjiyun/auto-enterview-fe/assets/141378574/6975a4d9-461b-40b6-a104-f49a42488b05)

7. 마이페이지에서 썼던 컴포넌트 RecruitBoard 랑 응시자 마이페이지에도 쓸 것 같아서 공통으로 뺐습니다. 

## 리뷰 요구사항

클릭 중인 step이랑 다른 step의 지원자를 클릭하면 confirm 받도록 했습니다.
지원자는 같은 단계에서만 여러명 선택이 가능합니다.
수정할 점 있으면 말씀해주세용
참고로 api 따라서 route 경로도 조금 수정했습니다 !

close #30
