### PR TITLE
채용공고 디테일 페이지 및 axios 수정

### DIFF
--- a/src/components/axios/http.ts
+++ b/src/components/axios/http.ts
@@ -1,6 +1,0 @@
-import { JobPosting } from "../type/jobPosting";
-import { http } from "./instances";
-
-export const postCompaniesJobPosting = (companyKey: number, jobPosting: JobPosting) => {
-  return http.post<JobPosting>(`/companies/${companyKey}/job-posting`, jobPosting);
-};

--- a/src/components/axios/http/jobPosting.ts
+++ b/src/components/axios/http/jobPosting.ts
@@ -1,0 +1,23 @@
+import { companyInfo } from "../../type/company";
+import { JobPosting, JobPostingList } from "../../type/jobPosting";
+import { http } from "../instances";
+
+export const postCompaniesJobPosting = (companyKey: number, jobPosting: JobPosting) => {
+  return http.post<JobPosting>(`/companies/${companyKey}/job-posting`, jobPosting);
+};
+
+export const postJobPostingApply = (jobPostingKey: number) => {
+  return http.post(`/job-posting/${jobPostingKey}`);
+};
+
+export const getJobPosting = (jobPostingKey: number) => {
+  return http.get<JobPosting>(`/common/job-postings/${jobPostingKey}`);
+};
+
+export const getCompanyPostedJobPostings = (companyKey: number) => {
+  return http.get<JobPostingList>(`/companies/${companyKey}/posted-job-postings`);
+};
+
+export const getCompanyInfomation = (companyKey: number) => {
+  return http.get<companyInfo>(`/companies/${companyKey}/information`);
+};

--- a/src/components/axios/instances.ts
+++ b/src/components/axios/instances.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosInstance, AxiosRequestConfig } from "axios";
 
 export const axiosInstance = axios.create({
-  baseURL: "교체예정",
+  baseURL: "http://13.125.179.134",
   timeout: 5000,
 });
 

--- a/src/components/common/Format.ts
+++ b/src/components/common/Format.ts
@@ -1,0 +1,19 @@
+/**
+ *
+ * @param number
+ * @returns 07
+ */
+export const getTwoDigit = (number: number) => {
+  return number < 10 ? `0${number}` : `${number}`;
+};
+
+/**
+ *
+ * @param date
+ * @returns `2024.07.09`
+ */
+export const getDateFormat = (date: Date) => {
+  return `${date.getFullYear()}.
+  ${getTwoDigit(date.getMonth() + 1)}.
+  ${getTwoDigit(date.getDate())}`;
+};

--- a/src/components/css/ReactIconButton.ts
+++ b/src/components/css/ReactIconButton.ts
@@ -1,0 +1,23 @@
+import styled from "styled-components";
+
+export const IconButton = styled.button`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: var(--button-radius);
+  font-size: 1.5rem;
+
+  &.cancel {
+    background-color: var(--bg-light-gray);
+    border: 1px solid var(--border-gray-100);
+  }
+  &.save {
+    background-color: #00cc21;
+  }
+  &.edit {
+    background-color: var(--primary-color);
+    color: #fff;
+  }
+`;

--- a/src/components/routes/CompanyMypage.tsx
+++ b/src/components/routes/CompanyMypage.tsx
@@ -7,6 +7,7 @@ import { IoMdClose } from "react-icons/io";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
 import { Container, Inner, SubTitle, UserName, Wrapper } from "../css/Common";
+import { IconButton } from "../css/ReactIconButton";
 
 const infoTitles = ["대표자", "설립년도", "주소", "사원수", "회사 홈페이지 URL"];
 
@@ -99,17 +100,17 @@ const CompanyMypage = () => {
             <Buttons>
               {editMode ? (
                 <>
-                  <Button className="cancel" onClick={cancelEdit}>
+                  <IconButton className="cancel" onClick={cancelEdit}>
                     <IoMdClose />
-                  </Button>
-                  <Button className="save" onClick={saveInfo}>
+                  </IconButton>
+                  <IconButton className="save" onClick={saveInfo}>
                     <GiSaveArrow />
-                  </Button>
+                  </IconButton>
                 </>
               ) : (
-                <Button className="edit" onClick={editInfo}>
+                <IconButton className="edit" onClick={editInfo}>
                   <CiEdit />
-                </Button>
+                </IconButton>
               )}
             </Buttons>
           </Top>
@@ -205,28 +206,6 @@ const Top = styled.div`
 const Buttons = styled.div`
   display: flex;
   gap: 0.5rem;
-`;
-
-const Button = styled.button`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 2rem;
-  height: 2rem;
-  border-radius: var(--button-radius);
-  font-size: 1.5rem;
-
-  &.cancel {
-    background-color: var(--bg-light-gray);
-    border: 1px solid var(--border-gray-100);
-  }
-  &.save {
-    background-color: #00cc21;
-  }
-  &.edit {
-    background-color: var(--primary-color);
-    color: #fff;
-  }
 `;
 
 const UserInfo = styled.div`

--- a/src/components/routes/CreateJobPost.tsx
+++ b/src/components/routes/CreateJobPost.tsx
@@ -5,8 +5,9 @@ import React, { useRef, useState } from "react";
 import { Helmet } from "react-helmet-async";
 import { useForm, Controller } from "react-hook-form";
 import { JobPosting } from "../type/jobPosting";
-import { postCompaniesJobPosting } from "../axios/http";
+import { postCompaniesJobPosting } from "../axios/http/jobPosting";
 import { useNavigate } from "react-router-dom";
+import { getTwoDigit } from "../common/Format";
 
 const CreateJobPost = () => {
   //enum
@@ -108,10 +109,6 @@ const CreateJobPost = () => {
   const uploadFile = (event: React.ChangeEvent<HTMLInputElement>) => {
     const value = event.target.value.split("\\");
     setFileName(value[value.length - 1]);
-  };
-
-  const getTwoDigit = (number: number) => {
-    return number < 10 ? `0${number}` : `${number}`;
   };
 
   const getStringWorkingHour = (startTime: Date, endTime: Date) => {

--- a/src/components/routes/JobPostDetail.tsx
+++ b/src/components/routes/JobPostDetail.tsx
@@ -1,5 +1,293 @@
+import styled from "styled-components";
+import { Container, Inner, Wrapper } from "../css/Common";
+import { CiEdit } from "react-icons/ci";
+import { IconButton } from "../css/ReactIconButton";
+
 const JobPostDetail = () => {
-  return <></>;
+  return (
+    <Wrapper className="text">
+      <Inner className="inner-1200">
+        <InfoMessage>서류 필터링에 걸리면 지원 불가 안내</InfoMessage>
+        <Container>
+          <Top>
+            <DeadLineContainer>
+              <p>마감일자</p>
+              <Dday>(D-1)</Dday>
+            </DeadLineContainer>
+            <h1>제목</h1>
+            <EditButton className="edit">
+              <CiEdit />
+            </EditButton>
+          </Top>
+          <InfoContainer>
+            <Info>
+              <InfoTitle>채용직무</InfoTitle>
+              <InfoDesc>안드로이드</InfoDesc>
+            </Info>
+            <Info>
+              <InfoTitle>기술스택</InfoTitle>
+              <InfoDesc>Kotlin</InfoDesc>
+            </Info>
+            <Info>
+              <InfoTitle>고용형태</InfoTitle>
+              <InfoDesc>정규직</InfoDesc>
+            </Info>
+            <Info>
+              <InfoTitle>근무시간</InfoTitle>
+              <InfoDesc>09:00 ~ 18:00</InfoDesc>
+            </Info>
+            <Info>
+              <InfoTitle>필요경력</InfoTitle>
+              <InfoDesc>3년</InfoDesc>
+            </Info>
+            <Info>
+              <InfoTitle>필요학력</InfoTitle>
+              <InfoDesc>4년제</InfoDesc>
+            </Info>
+            <Info>
+              <InfoTitle>급여</InfoTitle>
+              <InfoDesc>6000만원</InfoDesc>
+            </Info>
+            <Info>
+              <InfoTitle>접수기간</InfoTitle>
+              <InfoDesc>2024.07.08 ~ 2024.08.08</InfoDesc>
+            </Info>
+            <LongInfo>
+              <InfoTitle>근무지</InfoTitle>
+              <InfoDesc>부산광역시 강서구 녹산산단382로14번가길 10~29번지(송정동)</InfoDesc>
+            </LongInfo>
+            <LongInfo>
+              <InfoTitle>전형절차</InfoTitle>
+              <StepContainer>
+                <Step>
+                  <StepNumber>1단계</StepNumber>
+                  <p>서류전형</p>
+                </Step>
+                <Step>
+                  <StepNumber>2단계</StepNumber>
+                  <p>1차면면접차면접면면접면접접면접차면접면면접면접접면접차면접면면접면접접접</p>
+                </Step>
+                <Step>
+                  <StepNumber>3단계</StepNumber>
+                  <p>2차면접</p>
+                </Step>
+                <Step>
+                  <StepNumber>4단계</StepNumber>
+                  <p>2차면접</p>
+                </Step>
+                <Step>
+                  <StepNumber>5단계</StepNumber>
+                  <p>2차면접</p>
+                </Step>
+                <Step>
+                  <StepNumber>6단계</StepNumber>
+                  <p>면접차면접면면접면접접차면접</p>
+                </Step>
+                <Step>
+                  <StepNumber>7단계</StepNumber>
+                  <p>2차면접면접</p>
+                </Step>
+                <Step>
+                  <StepNumber>8단계</StepNumber>
+                  <p>2차면접</p>
+                </Step>
+                <Step>
+                  <StepNumber>9단계</StepNumber>
+                  <p>2차면접</p>
+                </Step>
+                <Step>
+                  <StepNumber>10단계</StepNumber>
+                  <p>2차면접</p>
+                </Step>
+              </StepContainer>
+            </LongInfo>
+          </InfoContainer>
+          <ContentsContianer>
+            <h2>공고내용</h2>
+            <div>
+              설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명
+            </div>
+            <ContentImage src="" alt="채용공고 설명 이미지" />
+          </ContentsContianer>
+        </Container>
+        <Container>
+          <h2>회사정보</h2>
+          <InfoContainer>
+            <CompanyName>(주)안드로메다</CompanyName>
+            <Info>
+              <InfoTitle>대표자</InfoTitle>
+              <InfoDesc>데애표</InfoDesc>
+            </Info>
+            <Info>
+              <InfoTitle>사원수</InfoTitle>
+              <InfoDesc>534명</InfoDesc>
+            </Info>
+            <Info>
+              <InfoTitle>회사 홈페이지</InfoTitle>
+              <InfoDesc>http://www.naver.com/</InfoDesc>
+            </Info>
+            <Info>
+              <InfoTitle>설립년도</InfoTitle>
+              <InfoDesc>1945년</InfoDesc>
+            </Info>
+            <LongInfo>
+              <InfoTitle>주소</InfoTitle>
+              <InfoDesc>부산광역시 강서구 녹산산단382로14번가길 10~29번지(송정동)</InfoDesc>
+            </LongInfo>
+          </InfoContainer>
+        </Container>
+        <ApplyButton>지원하기</ApplyButton>
+      </Inner>
+    </Wrapper>
+  );
 };
+
+const InfoMessage = styled.p`
+  text-align: center;
+  color: var(--color-red);
+`;
+
+const Top = styled.div`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+const DeadLineContainer = styled.div`
+  display: flex;
+  gap: 8px;
+`;
+
+const Dday = styled.div`
+  color: var(--color-red);
+`;
+
+const InfoContainer = styled.div`
+  display: grid;
+  grid-template-rows: repeat(4, 1fr);
+  grid-template-columns: repeat(2, 1fr);
+  column-gap: 16px;
+  row-gap: 40px;
+  padding: 40px;
+  background-color: var(--bg-light-blue);
+  border-radius: var(--box-radius);
+
+  @media screen and (max-width: 1000px) {
+    grid-template-columns: repeat(1, 1fr);
+  }
+`;
+
+const Info = styled.div`
+  display: flex;
+
+  @media screen and (max-width: 500px) {
+    flex-direction: column;
+    gap: 16px;
+  }
+`;
+
+const InfoTitle = styled.p`
+  width: 150px;
+  font-weight: 700;
+  flex-shrink: 0;
+`;
+
+const InfoDesc = styled.div``;
+
+const ContentsContianer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+`;
+
+const ContentImage = styled.img`
+  max-width: 100%;
+`;
+
+const LongInfo = styled(Info)`
+  grid-column-start: 1;
+  grid-column-end: 3;
+
+  @media screen and (max-width: 1000px) {
+    grid-column-end: 1;
+  }
+`;
+
+const StepContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 40px;
+
+  @media screen and (max-width: 500px) {
+    justify-content: center;
+  }
+`;
+
+const Step = styled.div`
+  width: 160px;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  text-align: center;
+
+  &:not(:first-child)::before {
+    content: "";
+    position: absolute;
+    top: calc(8px + 0.4rem);
+    left: -20px;
+    width: 63px;
+    height: 2px;
+    background-color: var(--primary-color);
+  }
+
+  &:not(:last-child)::after {
+    content: "";
+    position: absolute;
+    top: calc(8px + 0.4rem);
+    left: 117px;
+    width: 63px;
+    height: 2px;
+    background-color: var(--primary-color);
+  }
+`;
+
+const StepNumber = styled.div`
+  width: 74px;
+  padding: 8px 16px;
+  color: var(--primary-color);
+  font-size: 0.8rem;
+  font-weight: 700;
+  border: 2px solid var(--primary-color);
+  border-radius: var(--box-radius);
+`;
+
+const CompanyName = styled(LongInfo)`
+  font-size: 1.3rem;
+  font-weight: 700;
+`;
+
+const ApplyButton = styled.button`
+  margin: 100px auto;
+  padding: 32px 104px;
+  color: #ffffff;
+  font-size: 1.3rem;
+  font-weight: 700;
+  background-color: var(--primary-color);
+  border-radius: var(--button-radius);
+
+  transition: all 0.1s;
+  &:active {
+    transform: scale(99%);
+  }
+`;
+
+const EditButton = styled(IconButton)`
+  position: absolute;
+  top: 0;
+  right: 0;
+`;
 
 export default JobPostDetail;

--- a/src/components/routes/JobPostDetail.tsx
+++ b/src/components/routes/JobPostDetail.tsx
@@ -2,8 +2,71 @@ import styled from "styled-components";
 import { Container, Inner, Wrapper } from "../css/Common";
 import { CiEdit } from "react-icons/ci";
 import { IconButton } from "../css/ReactIconButton";
+import { getCompanyInfomation, getJobPosting, postJobPostingApply } from "../axios/http/jobPosting";
+import { useParams } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { JobPosting } from "../type/jobPosting";
+import { getDateFormat } from "../common/Format";
+import { companyInfo } from "../type/company";
 
 const JobPostDetail = () => {
+  const { postId } = useParams();
+
+  const [jobPostingInfo, setJobPostingInfo] = useState<JobPosting>({
+    companyKey: 1,
+    title: "공고제목이요",
+    jobCategory: "안드로이드",
+    career: 3,
+    techStack: ["Kotlin", "Spring Boot", "Java", "Node.js", "Python", "Dijango"],
+    jobPostingStep: ["서류전형", "1차면접", "2차면접"],
+    workLocation: "부산광역시 강서구 녹산산단382로14번가길 10~29번지(송정동)",
+    education: "4년제",
+    employmentType: "정규직",
+    salary: 3,
+    workTime: "09:00 ~ 18:00",
+    startDateTime: new Date(),
+    endDateTime: new Date(),
+    jobPostingContent:
+      " 설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명",
+    image: {
+      fileName: "파일명",
+      originalFileName: "원본파일명",
+      filePath: "url",
+    },
+  });
+  const [companyInfo, setCompanyInfo] = useState<companyInfo>({
+    companyInfoKey: "(주)안드로메다",
+    employees: 1315,
+    companyAge: new Date(),
+    companyUrl: "www.naver.com",
+    boss: "데애표",
+    address: "부산광역시 강서구 녹산산단382로14번가길 10~29번지(송정동)",
+  });
+
+  useEffect(() => {
+    async () => {
+      // 공고내용
+      const response = await getJobPosting(1);
+      setJobPostingInfo(response);
+
+      // 파일 해결되면 TODO: url 추출
+
+      // 회사정보
+      const companyResponse = await getCompanyInfomation(1);
+      setCompanyInfo(companyResponse);
+    };
+  }, []);
+
+  // 지원하기
+  const Apply = async () => {
+    if (!postId) return;
+
+    // TODO: 로그인하지 않았다면 로그인으로 보내기 alert
+
+    // 로그인한 사용자만
+    await postJobPostingApply(Number(postId));
+  };
+
   return (
     <Wrapper className="text">
       <Inner className="inner-1200">
@@ -14,7 +77,7 @@ const JobPostDetail = () => {
               <p>마감일자</p>
               <Dday>(D-1)</Dday>
             </DeadLineContainer>
-            <h1>제목</h1>
+            <h1>{jobPostingInfo?.title}</h1>
             <EditButton className="edit">
               <CiEdit />
             </EditButton>
@@ -22,121 +85,92 @@ const JobPostDetail = () => {
           <InfoContainer>
             <Info>
               <InfoTitle>채용직무</InfoTitle>
-              <InfoDesc>안드로이드</InfoDesc>
+              <InfoDesc>{jobPostingInfo?.jobCategory}</InfoDesc>
             </Info>
             <Info>
               <InfoTitle>기술스택</InfoTitle>
-              <InfoDesc>Kotlin</InfoDesc>
+              <InfoDesc>{jobPostingInfo?.techStack.map(stack => `${stack}, `)}</InfoDesc>
             </Info>
             <Info>
               <InfoTitle>고용형태</InfoTitle>
-              <InfoDesc>정규직</InfoDesc>
+              <InfoDesc>{jobPostingInfo?.employmentType}</InfoDesc>
             </Info>
             <Info>
               <InfoTitle>근무시간</InfoTitle>
-              <InfoDesc>09:00 ~ 18:00</InfoDesc>
+              <InfoDesc>{jobPostingInfo?.workTime}</InfoDesc>
             </Info>
             <Info>
               <InfoTitle>필요경력</InfoTitle>
-              <InfoDesc>3년</InfoDesc>
+              <InfoDesc>{jobPostingInfo?.career}년</InfoDesc>
             </Info>
             <Info>
               <InfoTitle>필요학력</InfoTitle>
-              <InfoDesc>4년제</InfoDesc>
+              <InfoDesc>{jobPostingInfo?.education}</InfoDesc>
             </Info>
             <Info>
               <InfoTitle>급여</InfoTitle>
-              <InfoDesc>6000만원</InfoDesc>
+              <InfoDesc>{jobPostingInfo?.salary}만원</InfoDesc>
             </Info>
             <Info>
               <InfoTitle>접수기간</InfoTitle>
-              <InfoDesc>2024.07.08 ~ 2024.08.08</InfoDesc>
+              <InfoDesc>
+                {getDateFormat(jobPostingInfo?.startDateTime)} ~{" "}
+                {getDateFormat(jobPostingInfo?.endDateTime)}
+              </InfoDesc>
             </Info>
             <LongInfo>
               <InfoTitle>근무지</InfoTitle>
-              <InfoDesc>부산광역시 강서구 녹산산단382로14번가길 10~29번지(송정동)</InfoDesc>
+              <InfoDesc>{jobPostingInfo.workLocation}</InfoDesc>
             </LongInfo>
             <LongInfo>
               <InfoTitle>전형절차</InfoTitle>
               <StepContainer>
-                <Step>
-                  <StepNumber>1단계</StepNumber>
-                  <p>서류전형</p>
-                </Step>
-                <Step>
-                  <StepNumber>2단계</StepNumber>
-                  <p>1차면면접차면접면면접면접접면접차면접면면접면접접면접차면접면면접면접접접</p>
-                </Step>
-                <Step>
-                  <StepNumber>3단계</StepNumber>
-                  <p>2차면접</p>
-                </Step>
-                <Step>
-                  <StepNumber>4단계</StepNumber>
-                  <p>2차면접</p>
-                </Step>
-                <Step>
-                  <StepNumber>5단계</StepNumber>
-                  <p>2차면접</p>
-                </Step>
-                <Step>
-                  <StepNumber>6단계</StepNumber>
-                  <p>면접차면접면면접면접접차면접</p>
-                </Step>
-                <Step>
-                  <StepNumber>7단계</StepNumber>
-                  <p>2차면접면접</p>
-                </Step>
-                <Step>
-                  <StepNumber>8단계</StepNumber>
-                  <p>2차면접</p>
-                </Step>
-                <Step>
-                  <StepNumber>9단계</StepNumber>
-                  <p>2차면접</p>
-                </Step>
-                <Step>
-                  <StepNumber>10단계</StepNumber>
-                  <p>2차면접</p>
-                </Step>
+                {jobPostingInfo.jobPostingStep.map((stepName, idx) => {
+                  return (
+                    <Step>
+                      <StepNumber>{idx + 1}단계</StepNumber>
+                      <p>{stepName}</p>
+                    </Step>
+                  );
+                })}
               </StepContainer>
             </LongInfo>
           </InfoContainer>
           <ContentsContianer>
             <h2>공고내용</h2>
-            <div>
-              설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명설명
-            </div>
-            <ContentImage src="" alt="채용공고 설명 이미지" />
+            <div>{jobPostingInfo.jobPostingContent}</div>
+            {jobPostingInfo.image.fileName && (
+              <ContentImage src={jobPostingInfo.image.filePath} alt="채용공고 설명 이미지" />
+            )}
           </ContentsContianer>
         </Container>
         <Container>
           <h2>회사정보</h2>
           <InfoContainer>
-            <CompanyName>(주)안드로메다</CompanyName>
+            <CompanyName>{companyInfo.companyInfoKey}</CompanyName>
             <Info>
               <InfoTitle>대표자</InfoTitle>
-              <InfoDesc>데애표</InfoDesc>
+              <InfoDesc>{companyInfo.boss}</InfoDesc>
             </Info>
             <Info>
               <InfoTitle>사원수</InfoTitle>
-              <InfoDesc>534명</InfoDesc>
+              <InfoDesc>{companyInfo.employees}명</InfoDesc>
             </Info>
             <Info>
               <InfoTitle>회사 홈페이지</InfoTitle>
-              <InfoDesc>http://www.naver.com/</InfoDesc>
+              <InfoDesc>{companyInfo.companyUrl}</InfoDesc>
             </Info>
             <Info>
               <InfoTitle>설립년도</InfoTitle>
-              <InfoDesc>1945년</InfoDesc>
+              <InfoDesc>{companyInfo.companyAge.getFullYear()}년</InfoDesc>
             </Info>
             <LongInfo>
               <InfoTitle>주소</InfoTitle>
-              <InfoDesc>부산광역시 강서구 녹산산단382로14번가길 10~29번지(송정동)</InfoDesc>
+              <InfoDesc>{companyInfo.address}</InfoDesc>
             </LongInfo>
           </InfoContainer>
         </Container>
-        <ApplyButton>지원하기</ApplyButton>
+        <ApplyButton onClick={Apply}>지원하기</ApplyButton>
       </Inner>
     </Wrapper>
   );

--- a/src/components/type/company.ts
+++ b/src/components/type/company.ts
@@ -1,0 +1,8 @@
+export interface companyInfo {
+  companyInfoKey: string;
+  employees: number;
+  companyAge: Date;
+  companyUrl: string;
+  boss: string;
+  address: string;
+}

--- a/src/components/type/jobPosting.ts
+++ b/src/components/type/jobPosting.ts
@@ -1,4 +1,5 @@
 export interface JobPosting {
+  companyKey: 1;
   title: string;
   jobCategory: string;
   career: number;
@@ -7,10 +8,10 @@ export interface JobPosting {
   workLocation: string;
   education: string;
   employmentType: string;
-  salary: string;
+  salary: number;
   workTime: string;
-  startDateTime: string;
-  endDateTime: string;
+  startDateTime: Date;
+  endDateTime: Date;
   jobPostingContent: string;
   image: {
     fileName: string;
@@ -18,3 +19,13 @@ export interface JobPosting {
     filePath: string;
   };
 }
+
+export interface JobPostingForCompany {
+  jobPostingkey: string;
+  title: string;
+  jobCategory: string;
+  startDateTime: Date;
+  endDateTime: Date;
+}
+
+export type JobPostingList = JobPostingForCompany[];


### PR DESCRIPTION
## 작업 내용
1. 채용공고 마크업
2. reacticon 사용하는 곳이 중복되어 공통 css로 뺐습니다.
3. 채용공고 불러오기 api
4. 채용공고 지원하기
5. axios ip 수정하였습니다.
6. http 를 폴더로 나누었습니다.
7. api 불러오면서 필요한 type를 선언해주었습니다.


## 스크린샷(선택)

![image](https://github.com/cheonjiyun/auto-enterview-fe/assets/70828192/cad0170c-adff-4ab9-9581-643527f79153)

## 리뷰 요구사항
단계 예쁘죠

## 연관된 이슈

close #37 
