### PR TITLE
[지원자] 마이페이지 UI 구현

### DIFF
--- a/src/components/axios/http/resume.ts
+++ b/src/components/axios/http/resume.ts
@@ -1,0 +1,12 @@
+import { Method } from "../../type/resume";
+import { http } from "../instances";
+
+const resumeEndpoint = (method: Method, candidateKey: string) => {
+  const url = `/candidates/${candidateKey}/resume`;
+  return http[method](url);
+};
+
+export const getResume = (candidateKey: string) => resumeEndpoint("get", candidateKey);
+export const postResume = (candidateKey: string) => resumeEndpoint("post", candidateKey);
+export const putResume = (candidateKey: string) => resumeEndpoint("put", candidateKey);
+export const deleteResume = (candidateKey: string) => resumeEndpoint("delete", candidateKey);

--- a/src/components/css/MypageStyle.ts
+++ b/src/components/css/MypageStyle.ts
@@ -1,0 +1,80 @@
+import styled from "styled-components";
+
+export const Top = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+`;
+
+export const UserInfo = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(48%, 1fr));
+  row-gap: 40px;
+  column-gap: 4%;
+  padding: 40px;
+  background-color: var(--bg-light-blue);
+`;
+
+export const Info = styled.div`
+  display: flex;
+  gap: 1rem;
+`;
+
+export const InfoTitle = styled.p`
+  width: 150px;
+  font-weight: 700;
+`;
+
+export const InfoDesc = styled.p`
+  width: calc(100% - 150px);
+`;
+
+export const RecruitLists = styled.ul`
+  display: flex;
+  flex-direction: column;
+  padding: 16px 32px;
+  border: 1px solid var(--border-gray-100);
+  border-radius: var(--box-radius);
+`;
+
+export const RecruitList = styled.li`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  padding: 1rem 0;
+  cursor: pointer;
+  &:not(:last-child) {
+    border-bottom: 1px solid var(--border-gray-100);
+  }
+`;
+
+export const LabelWrap = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+`;
+
+export const Label = styled.span`
+  display: inline-block;
+  width: 0.5rem;
+  height: 2rem;
+  background-color: #00cc21;
+`;
+
+export const Dday = styled.p``;
+
+export const ListTitle = styled.h4`
+  width: 100%;
+  max-width: 450px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+export const ListCareer = styled.p``;
+
+export const ListStep = styled.p`
+  flex-shrink: 0;
+  font-weight: 700;
+`;

--- a/src/components/routes/CompanyMypage.tsx
+++ b/src/components/routes/CompanyMypage.tsx
@@ -8,6 +8,21 @@ import { Link } from "react-router-dom";
 import styled from "styled-components";
 import { Container, Inner, SubTitle, UserName, Wrapper } from "../css/Common";
 import { IconButton } from "../css/ReactIconButton";
+import {
+  Dday,
+  Info,
+  InfoDesc,
+  InfoTitle,
+  Label,
+  LabelWrap,
+  ListCareer,
+  ListStep,
+  ListTitle,
+  RecruitList,
+  RecruitLists,
+  Top,
+  UserInfo,
+} from "../css/MypageStyle";
 
 const infoTitles = ["대표자", "설립년도", "주소", "사원수", "회사 홈페이지 URL"];
 
@@ -197,34 +212,9 @@ const CompanyMypage = () => {
   );
 };
 
-const Top = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-`;
-
 const Buttons = styled.div`
   display: flex;
   gap: 0.5rem;
-`;
-
-const UserInfo = styled.div`
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(48%, 1fr));
-  row-gap: 40px;
-  column-gap: 4%;
-  padding: 40px;
-  background-color: var(--bg-light-blue);
-`;
-
-const Info = styled.div`
-  display: flex;
-  gap: 1rem;
-`;
-
-const InfoTitle = styled.p`
-  width: 150px;
-  font-weight: 700;
 `;
 
 const InfoInput = styled.input`
@@ -247,10 +237,6 @@ const InfoInput = styled.input`
   }
 `;
 
-const InfoDesc = styled.p`
-  width: calc(100% - 150px);
-`;
-
 const CreatePost = styled(Link)`
   display: flex;
   justify-content: center;
@@ -261,52 +247,6 @@ const CreatePost = styled(Link)`
   background-color: var(--primary-color);
   font-size: 1.5rem;
   color: #fff;
-`;
-
-const RecruitLists = styled.ul`
-  display: flex;
-  flex-direction: column;
-  padding: 1rem 2rem;
-  border: 1px solid var(--border-gray-100);
-  border-radius: var(--box-radius);
-`;
-
-const RecruitList = styled.li`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 1rem 0;
-  &:not(:last-child) {
-    border-bottom: 1px solid var(--border-gray-100);
-  }
-`;
-
-const LabelWrap = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-`;
-
-const Label = styled.span`
-  display: inline-block;
-  width: 0.5rem;
-  height: 2rem;
-  background-color: #00cc21;
-`;
-
-const Dday = styled.p``;
-
-const ListTitle = styled.h4`
-  width: 450px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-`;
-
-const ListCareer = styled.p``;
-
-const ListStep = styled.p`
-  font-weight: 700;
 `;
 
 export default CompanyMypage;

--- a/src/components/routes/FormAssignment.tsx
+++ b/src/components/routes/FormAssignment.tsx
@@ -1,4 +1,3 @@
-import styled from "styled-components";
 import { Buttons, CreateButton, Form, Label, NextButton, Settings } from "../css/ScheduleFormStyle";
 
 const FormAssignment = () => {

--- a/src/components/routes/UserMypage.tsx
+++ b/src/components/routes/UserMypage.tsx
@@ -22,7 +22,7 @@ import { useRecoilValue } from "recoil";
 const infoTitles = ["이름", "이메일", "휴대폰 번호"];
 
 const UserMypage = () => {
-  const [isResume, setIsResume] = useState(false);
+  const [isResume, setIsResume] = useState(true);
   // todo: 로그인한 유저 정보
   const currentUserKey = "id";
   // const currentUserKey = useRecoilValue()
@@ -31,8 +31,8 @@ const UserMypage = () => {
     // 이력서가 등록되어 있는지 확인
     const fetchResume = async () => {
       try {
-        await getResume(currentUserKey);
-        setIsResume(true);
+        const response = await getResume(currentUserKey);
+        if (response.length) setIsResume(true);
       } catch (error) {
         alert("이력서를 불러오는데 문제가 생겼습니다.");
         setIsResume(false);

--- a/src/components/routes/UserMypage.tsx
+++ b/src/components/routes/UserMypage.tsx
@@ -1,5 +1,111 @@
+import styled from "styled-components";
+import { Container, Inner, SubTitle, Wrapper } from "../css/Common";
+import {
+  Dday,
+  Info,
+  InfoDesc,
+  InfoTitle,
+  Label,
+  LabelWrap,
+  ListStep,
+  ListTitle,
+  RecruitList,
+  RecruitLists,
+  Top,
+  UserInfo,
+} from "../css/MypageStyle";
+import { useEffect, useState } from "react";
+import { getResume } from "../axios/http/resume";
+import { Link } from "react-router-dom";
+import { useRecoilValue } from "recoil";
+
+const infoTitles = ["이름", "이메일", "휴대폰 번호"];
+
 const UserMypage = () => {
-  return <></>;
+  const [isResume, setIsResume] = useState(false);
+  // todo: 로그인한 유저 정보
+  const currentUserKey = "id";
+  // const currentUserKey = useRecoilValue()
+
+  useEffect(() => {
+    // 이력서가 등록되어 있는지 확인
+    const fetchResume = async () => {
+      try {
+        await getResume(currentUserKey);
+        setIsResume(true);
+      } catch (error) {
+        alert("이력서를 불러오는데 문제가 생겼습니다.");
+        setIsResume(false);
+      }
+    };
+    fetchResume();
+  }, []);
+
+  return (
+    <Wrapper>
+      <Inner className="inner-1200">
+        <Container>
+          <UserTop>
+            <SubTitle>응시자 정보</SubTitle>
+            {isResume ? (
+              <ReadResume to={`/view-resume/${currentUserKey}`}>이력서 보기</ReadResume>
+            ) : (
+              <CreateResume to="/create-resume">이력서 생성</CreateResume>
+            )}
+          </UserTop>
+          <UserInfo>
+            {infoTitles.map(info => (
+              <Info className="text" key={info}>
+                <InfoTitle>{info}</InfoTitle>
+                <InfoDesc>{info}</InfoDesc>
+              </Info>
+            ))}
+          </UserInfo>
+        </Container>
+        <Container>
+          <SubTitle className="sub-title">내가 지원한 공고 목록</SubTitle>
+          <RecruitLists>
+            <RecruitList>
+              <LabelWrap>
+                <Label />
+                <Dday>{"2024.06.26"}</Dday>
+              </LabelWrap>
+              <Time>{"14:00"}</Time>
+              <ListStep>{"서류 단계"}</ListStep>
+              <UserListTitle>
+                {
+                  "제목입니다ㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏ"
+                }
+              </UserListTitle>
+            </RecruitList>
+          </RecruitLists>
+        </Container>
+      </Inner>
+    </Wrapper>
+  );
 };
+
+const UserTop = styled(Top)`
+  justify-content: space-between;
+`;
+
+const Time = styled(Dday)``;
+
+const ReadResume = styled(Link)`
+  padding: 16px 48px;
+  background-color: var(--sub-color);
+  border-radius: var(--button-radius);
+  font-size: 1.2rem;
+  color: #fff;
+`;
+
+const CreateResume = styled(ReadResume)`
+  background-color: var(--primary-color);
+`;
+
+const UserListTitle = styled(ListTitle)`
+  max-width: 600px;
+  padding-right: 24px;
+`;
 
 export default UserMypage;

--- a/src/components/type/resume.ts
+++ b/src/components/type/resume.ts
@@ -1,0 +1,1 @@
+export type Method = "get" | "post" | "put" | "delete";


### PR DESCRIPTION
## 작업 내용

1. [지원자] 마이페이지 UI 구현
2. 버튼은 이력서가 있는지에 따라 [이력서 보기] / [이력서 생성] 으로 토글됩니다.
3. recoil로 현재 user 정보 받아오도록 주석처리 해놨습니다
4. response 체크하는 부분은 다시 커밋했습니다
5. 내가 지원한 공고 목록을 클릭하면 디테일 페이지로 이동합니다.

## 스크린샷
![image](https://github.com/cheonjiyun/auto-enterview-fe/assets/141378574/5fba2e2c-3093-46f3-b1bd-fe02733831e1)
![image](https://github.com/cheonjiyun/auto-enterview-fe/assets/141378574/8e35af94-17ca-4186-8c2b-3a3217b543e2)


## 리뷰 요구사항

지원했는데 떨어진 공고는 어떻게 처리할까요??


close #45
