### PR TITLE
채용단계 모달창 date-picker 적용 및 date-picker props 추가 / 스타일 변경

### DIFF
--- a/src/components/css/ScheduleFormStyle.ts
+++ b/src/components/css/ScheduleFormStyle.ts
@@ -1,6 +1,7 @@
 import styled from "styled-components";
 
-export const Form = styled.div`
+export const Form = styled.form`
+  width: 100%;
   height: 100%;
 
   button {
@@ -13,10 +14,29 @@ export const Form = styled.div`
 `;
 
 export const Settings = styled.div`
-  height: calc(100% - 66px);
+  display: flex;
+  align-items: flex-start;
+  width: 100%;
+  height: calc(100% - 80px);
+`;
+
+export const Field = styled.div`
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  padding: 24px 0 32px;
+  background-color: var(--bg-light-blue);
+  border-radius: var(--box-radius);
+  text-align: center;
 `;
 
 export const Label = styled.label``;
+
+export const Text = styled.p`
+  margin-bottom: 16px;
+  font-weight: 500;
+`;
 
 export const Buttons = styled.div`
   display: flex;

--- a/src/components/css/input.ts
+++ b/src/components/css/input.ts
@@ -63,20 +63,12 @@ export const DatePickerContainer = styled.div`
   width: 150px;
 
   .react-datepicker-popper {
-    z-index: 2;
+    z-index: 10;
 
     position: relative;
     background-color: #ffffff;
     border: 1px solid #b7b7b7;
     border-radius: var(--button-radius);
-  }
-
-  &:nth-child(1) .react-datepicker-popper {
-    transform: translate(0, -300px) !important;
-  }
-
-  &:nth-child(3) .react-datepicker-popper {
-    transform: translate(-137px, -300px) !important;
   }
 
   .react-datepicker__aria-live {
@@ -186,7 +178,9 @@ export const DatePickerContainer = styled.div`
       background-color: var(--primary-color);
     }
 
-    &.react-datepicker__day--in-range:not(.react-datepicker__day--in-selecting-range) {
+    &.react-datepicker__day--in-range:not(
+        .react-datepicker__day--in-selecting-range
+      ) {
       color: var(--text-black);
       background-color: var(--bg-light-blue);
     }

--- a/src/components/input/DatePickerOne.tsx
+++ b/src/components/input/DatePickerOne.tsx
@@ -1,9 +1,24 @@
 import DatePicker from "react-datepicker";
 import { DataPickerInput, DatePickerContainer } from "../css/input";
 
+export type Placement =
+  | "top"
+  | "top-start"
+  | "top-end"
+  | "bottom"
+  | "bottom-start"
+  | "bottom-end"
+  | "right"
+  | "right-start"
+  | "right-end"
+  | "left"
+  | "left-start"
+  | "left-end";
+
 interface Props {
   value: Date;
   onChange: (date: Date) => void;
+  popperPlacement?: Placement;
 }
 
 /**
@@ -11,7 +26,11 @@ interface Props {
  * 날짜값 변수(value)와 선택되었을 때 값을 바꾸어주는 함수(onChange)를 넘겨야 합니다.
  */
 
-const DatePickerOne = ({ value, onChange }: Props) => {
+const DatePickerOne = ({
+  value,
+  onChange,
+  popperPlacement = "bottom",
+}: Props) => {
   return (
     <>
       <DatePickerContainer>
@@ -21,6 +40,7 @@ const DatePickerOne = ({ value, onChange }: Props) => {
           selectsStart
           dateFormat="YYYY.MM.dd"
           customInput={<DataPickerInput />}
+          popperPlacement={popperPlacement}
         />
       </DatePickerContainer>
     </>

--- a/src/components/input/TimePicker.tsx
+++ b/src/components/input/TimePicker.tsx
@@ -1,14 +1,21 @@
 import styled from "styled-components";
 import { DataPickerInput } from "../css/input";
 import DatePicker from "react-datepicker";
+import { Placement } from "./DatePickerOne";
 
 interface Props {
   value: Date;
   onChange: (date: Date) => void;
   disabled?: boolean;
+  popperPlacement?: Placement;
 }
 
-const TimePicker = ({ value, onChange, disabled }: Props) => {
+const TimePicker = ({
+  value,
+  onChange,
+  disabled,
+  popperPlacement = "bottom",
+}: Props) => {
   return (
     <TimePickerContainer>
       <DatePicker
@@ -22,6 +29,7 @@ const TimePicker = ({ value, onChange, disabled }: Props) => {
         timeCaption=""
         customInput={<DataPickerInput />}
         disabled={disabled}
+        popperPlacement={popperPlacement}
       />
     </TimePickerContainer>
   );
@@ -30,13 +38,13 @@ const TimePicker = ({ value, onChange, disabled }: Props) => {
 const TimePickerContainer = styled.div`
   position: relative;
   width: 100px;
-  z-index: 2;
+  z-index: 10;
 
   .react-datepicker-popper {
+    width: 100%;
     background-color: #ffffff;
     border: 1px solid #b7b7b7;
     border-radius: var(--button-radius);
-    transform: translate(0px, -250px) !important;
   }
 
   .react-datepicker__triangle {
@@ -50,7 +58,7 @@ const TimePickerContainer = styled.div`
 
   .react-datepicker__time-list-item {
     list-style: none;
-    width: 100px;
+    width: 100%;
     padding: 8px;
     text-align: center;
     cursor: pointer;

--- a/src/components/routes/FormAssignment.tsx
+++ b/src/components/routes/FormAssignment.tsx
@@ -1,33 +1,42 @@
-import { Buttons, CreateButton, Form, Label, NextButton, Settings } from "../css/ScheduleFormStyle";
+import { useState } from "react";
+import {
+  Buttons,
+  CreateButton,
+  Field,
+  Form,
+  Label,
+  NextButton,
+  Settings,
+  Text,
+} from "../css/ScheduleFormStyle";
+import DatePickerOne from "../input/DatePickerOne";
+import TimePicker from "../input/TimePicker";
 
 const FormAssignment = () => {
+  const [formData, setFormData] = useState({
+    endDate: new Date(),
+    endHour: new Date(2024, 7, 13, 18, 0),
+  });
+
   return (
     <Form>
       <Settings>
-        <Label htmlFor="date">날짜</Label>
-        <Label htmlFor="time">시간</Label>
-        {/* <Controller
-        control={control}
-        name="time"
-        rules={{ required: "근무시간을 선택해주세요." }}
-        defaultValue={new Date(2024, 7, 13, 9, 0)}
-        render={({ field: { onChange, value } }) => (
-          <TimePickerContainer>
-            <DatePicker
-              selected={value}
-              onChange={date => onChange(date)}
-              showTimeSelect
-              showTimeSelectOnly
-              timeIntervals={30}
-              dateFormat="HH:mm"
-              timeFormat="HH:mm"
-              timeCaption=""
-              customInput={<TimeInput />}
-              disabled={freeHour}
+        <Field>
+          <Label>
+            <Text>과제 마감 날짜</Text>
+            <DatePickerOne
+              value={formData.endDate}
+              onChange={date => setFormData({ ...formData, endDate: date })}
             />
-          </TimePickerContainer>
-        )}
-      /> */}
+          </Label>
+          <Label>
+            <Text>시간</Text>
+            <TimePicker
+              value={formData.endHour}
+              onChange={date => setFormData({ ...formData, endHour: date })}
+            />
+          </Label>
+        </Field>
       </Settings>
       <Buttons>
         <CreateButton className="btn">일정 저장하기</CreateButton>

--- a/src/components/routes/FormInterview.tsx
+++ b/src/components/routes/FormInterview.tsx
@@ -1,35 +1,75 @@
-import { Buttons, CreateButton, Form, Label, NextButton, Settings } from "../css/ScheduleFormStyle";
+import { useState } from "react";
+import {
+  Buttons,
+  CreateButton,
+  Field,
+  Form,
+  Label,
+  NextButton,
+  Settings,
+  Text,
+} from "../css/ScheduleFormStyle";
+import DatePickerOne from "../input/DatePickerOne";
+import TimePicker from "../input/TimePicker";
+import { InputDefault } from "../css/input";
+import styled from "styled-components";
+
+interface IInterviewData {
+  startDate: Date;
+  startHour: Date;
+  term: number;
+  count: number;
+}
 
 const FormInterview = () => {
+  const [formData, setFormData] = useState<IInterviewData>({
+    startDate: new Date(),
+    startHour: new Date(2024, 7, 13, 18, 0),
+    term: 0,
+    count: 0,
+  });
+  const [dataList, setDataList] = useState<IInterviewData[]>([]);
+
   return (
     <Form>
       <Settings>
-        <Label htmlFor="date">날짜</Label>
-        <Label htmlFor="time">시간</Label>
-        <Label htmlFor="term">간격</Label>
-        <Label htmlFor="count">횟수</Label>
-        {/* <Controller
-      control={control}
-      name="time"
-      rules={{ required: "근무시간을 선택해주세요." }}
-      defaultValue={new Date(2024, 7, 13, 9, 0)}
-      render={({ field: { onChange, value } }) => (
-        <TimePickerContainer>
-          <DatePicker
-            selected={value}
-            onChange={date => onChange(date)}
-            showTimeSelect
-            showTimeSelectOnly
-            timeIntervals={30}
-            dateFormat="HH:mm"
-            timeFormat="HH:mm"
-            timeCaption=""
-            customInput={<TimeInput />}
-            disabled={freeHour}
-          />
-        </TimePickerContainer>
-      )}
-    /> */}
+        <Field>
+          <Label>
+            <Text>면접 날짜</Text>
+            <DatePickerOne
+              value={formData.startDate}
+              onChange={date => setFormData({ ...formData, startDate: date })}
+            />
+          </Label>
+          <Label>
+            <Text>시작 시간</Text>
+            <TimePicker
+              value={formData.startHour}
+              onChange={date => setFormData({ ...formData, startHour: date })}
+            />
+          </Label>
+          <Label>
+            <Text>간격(분)</Text>
+            <NumberInput
+              type="number"
+              placeholder="공고 제목을 입력하세요"
+              value={formData.term}
+              onChange={e => setFormData({ ...formData, term: e.target.value })}
+            />
+          </Label>
+          <Label>
+            <Text>횟수</Text>
+            <NumberInput
+              type="number"
+              placeholder="공고 제목을 입력하세요"
+              value={formData.count}
+              onChange={e =>
+                setFormData({ ...formData, count: e.target.value })
+              }
+            />
+          </Label>
+          <AddButton>일정 추가</AddButton>
+        </Field>
       </Settings>
       <Buttons>
         <CreateButton className="btn">일정 저장하기</CreateButton>
@@ -38,5 +78,20 @@ const FormInterview = () => {
     </Form>
   );
 };
+
+const NumberInput = styled(InputDefault)`
+  width: 60px;
+  background-color: #fff;
+  border: 1px solid var(--border-gray-100);
+  text-align: right;
+`;
+
+const AddButton = styled.button`
+  align-self: flex-end;
+  font-size: 1.2rem;
+  padding: 16px 32px;
+  background-color: var(--sub-color);
+  color: #fff;
+`;
 
 export default FormInterview;

--- a/src/components/routes/Modal.tsx
+++ b/src/components/routes/Modal.tsx
@@ -55,7 +55,11 @@ const Modal = ({ type, id, step, onClose }: ModalProps) => {
             <SubTitle>예약 메일 발송하기</SubTitle>
             <Field>
               <Form>
-                <TextArea name="email" id="email" onChange={e => handleOnChange(e)}>
+                <TextArea
+                  name="email"
+                  id="email"
+                  onChange={e => handleOnChange(e)}
+                >
                   {emailText}
                 </TextArea>
                 <Label htmlFor="date">날짜</Label>
@@ -181,66 +185,5 @@ const Field = styled.div`
 `;
 
 const TextArea = styled.textarea``;
-
-const TimePickerContainer = styled.div`
-  position: relative;
-  z-index: 2;
-
-  .react-datepicker-popper {
-    background-color: #ffffff;
-    border: 1px solid #b7b7b7;
-    border-radius: var(--button-radius);
-    transform: translate(0px, -250px) !important;
-  }
-
-  .react-datepicker__triangle {
-    display: none;
-  }
-
-  .react-datepicker__time-list {
-    height: 250px;
-    overflow-y: scroll;
-  }
-
-  .react-datepicker__time-list-item {
-    list-style: none;
-    width: 100px;
-    padding: 8px;
-    text-align: center;
-    cursor: pointer;
-
-    &:hover {
-      color: #ffffff;
-      background-color: var(--primary-color);
-    }
-
-    &[aria-selected="true"] {
-      color: #ffffff;
-      background-color: var(--primary-color);
-    }
-  }
-
-  .react-datepicker__aria-live {
-    display: none;
-  }
-`;
-
-const TimeInput = styled.input`
-  display: inline-block;
-  width: 100px;
-  text-align: center;
-  padding: 16px;
-  border: 1px solid #b7b7b7;
-  border-radius: 8px;
-  cursor: pointer;
-  word-break: keep-all;
-  font-size: 1rem;
-
-  &:disabled {
-    border: 1px solid var(--bg-light-gray);
-    color: var(--bg-light-gray);
-    background-color: #f8f8f8;
-  }
-`;
 
 export default Modal;


### PR DESCRIPTION
## 작업 내용

1. 채용단계 모달창 date-picker 적용
2. date-picker props 추가(위치 조정 props)
3. date-picker 스타일 변경(transform 제거)

## 스크린샷
![image](https://github.com/cheonjiyun/auto-enterview-fe/assets/141378574/d5568cd1-ab8c-42f9-845e-bce257f71496)
![image](https://github.com/cheonjiyun/auto-enterview-fe/assets/141378574/c3bc3808-1bfd-456e-a909-6d96cf4dbdf4)


## 리뷰 요구사항

date-picker 수정된 부분 확인해주세용
popperPlacement의 타입은 튜플타입으로 미리 지정해놨으니 필요하신걸로 찾아서 쓰시면 됩니다 !
[일정 추가] 버튼은 아직 이벤트 구현안했습니다 date-picker만 적용했습니당


close #51
