### PR TITLE
일정생성 기능구현 및 예약메일 UI 완료 / time 포맷 추가

### DIFF
--- a/src/assets/style/ReactIconButton.ts
+++ b/src/assets/style/ReactIconButton.ts
@@ -20,4 +20,7 @@ export const IconButton = styled.button`
     background-color: var(--primary-color);
     color: #fff;
   }
+  &.delete {
+    color: var(--color-red);
+  }
 `;

--- a/src/assets/style/ScheduleFormStyle.ts
+++ b/src/assets/style/ScheduleFormStyle.ts
@@ -3,8 +3,9 @@ import styled from "styled-components";
 export const Form = styled.form`
   width: 100%;
   height: 100%;
+  max-height: 432px;
 
-  button {
+  .btn {
     padding: 16px 32px;
     border-radius: var(--button-radius);
     font: inherit;
@@ -15,9 +16,10 @@ export const Form = styled.form`
 
 export const Settings = styled.div`
   display: flex;
-  align-items: flex-start;
+  flex-direction: column;
   width: 100%;
-  height: calc(100% - 80px);
+  height: 100%;
+  max-height: calc(100% - 80px);
 `;
 
 export const Field = styled.div`
@@ -25,7 +27,7 @@ export const Field = styled.div`
   justify-content: center;
   gap: 8px;
   width: 100%;
-  padding: 24px 0 32px;
+  padding: 24px 0;
   background-color: var(--bg-light-blue);
   border-radius: var(--box-radius);
   text-align: center;
@@ -42,6 +44,7 @@ export const Buttons = styled.div`
   display: flex;
   justify-content: center;
   gap: 8px;
+  margin-top: 16px;
 `;
 
 export const CreateButton = styled.button`

--- a/src/axios/http/interview.ts
+++ b/src/axios/http/interview.ts
@@ -1,0 +1,16 @@
+import { IInterviewProps } from "../../type/interview";
+import { http } from "../instances";
+
+export const getInterviewSchedule = (props: IInterviewProps) => {
+  return http.get(`/job-postings/${props.jobPostingKey}/steps/${props.stepId}/interview-schedule`);
+};
+
+export const postInterviewParticipants = (props: IInterviewProps) => {
+  return http.post(
+    `/job-postings/${props.jobPostingKey}/steps/${props.stepId}/interview-schedule-participants`,
+  );
+};
+
+export const postInterviewSchedule = (props: IInterviewProps) => {
+  return http.get(`/job-postings/${props.jobPostingKey}/steps/${props.stepId}/interview-schedule`);
+};

--- a/src/axios/http/resume.ts
+++ b/src/axios/http/resume.ts
@@ -1,4 +1,4 @@
-import { Method } from "../../../type/resume";
+import { Method } from "../../type/resume";
 import { http } from "../instances";
 
 const resumeEndpoint = (method: Method, candidateKey: string) => {

--- a/src/pages/FormAssignment.tsx
+++ b/src/pages/FormAssignment.tsx
@@ -11,12 +11,15 @@ import {
 } from "../assets/style/ScheduleFormStyle";
 import DatePickerOne from "../components/input/DatePickerOne";
 import TimePicker from "../components/input/TimePicker";
+import { SendScheduleConText } from "../type/interview";
+import { useOutletContext } from "react-router-dom";
 
 const FormAssignment = () => {
   const [formData, setFormData] = useState({
     endDate: new Date(),
     endHour: new Date(2024, 7, 13, 18, 0),
   });
+  const { sendSchedule, clickNext } = useOutletContext<SendScheduleConText>();
 
   return (
     <Form>
@@ -39,8 +42,12 @@ const FormAssignment = () => {
         </Field>
       </Settings>
       <Buttons>
-        <CreateButton className="btn">일정 저장하기</CreateButton>
-        <NextButton className="btn">다음</NextButton>
+        <CreateButton className="btn" type="button" onClick={sendSchedule}>
+          일정 저장하기
+        </CreateButton>
+        <NextButton className="btn" type="button" onClick={clickNext}>
+          다음
+        </NextButton>
       </Buttons>
     </Form>
   );

--- a/src/pages/FormInterview.tsx
+++ b/src/pages/FormInterview.tsx
@@ -13,22 +13,33 @@ import DatePickerOne from "../components/input/DatePickerOne";
 import TimePicker from "../components/input/TimePicker";
 import { InputDefault } from "../assets/style/input";
 import styled from "styled-components";
-
-interface IInterviewData {
-  startDate: Date;
-  startHour: Date;
-  term: number;
-  count: number;
-}
+import { getDateFormat, getTimeFormat } from "../utils/Format";
+import { RiDeleteBin6Line } from "react-icons/ri";
+import { IconButton } from "../assets/style/ReactIconButton";
+import { useOutletContext } from "react-router-dom";
+import { IInterviewData, SendScheduleConText } from "../type/interview";
 
 const FormInterview = () => {
   const [formData, setFormData] = useState<IInterviewData>({
-    startDate: new Date(),
-    startHour: new Date(2024, 7, 13, 18, 0),
+    date: new Date(),
+    startTime: new Date(2024, 7, 13, 18, 0),
     term: 0,
-    count: 0,
+    times: 0,
   });
   const [dataList, setDataList] = useState<IInterviewData[]>([]);
+  const { sendSchedule, clickNext } = useOutletContext<SendScheduleConText>();
+
+  // 면접일정 추가
+  const handleAdd = () => {
+    setDataList([...dataList, formData]);
+  };
+
+  // 추가한 면접일정 삭제
+  const handleDelete = (idx: number) => {
+    const deletedList = [...dataList];
+    deletedList.splice(idx, 1);
+    setDataList(deletedList);
+  };
 
   return (
     <Form>
@@ -37,15 +48,15 @@ const FormInterview = () => {
           <Label>
             <Text>면접 날짜</Text>
             <DatePickerOne
-              value={formData.startDate}
-              onChange={date => setFormData({ ...formData, startDate: date })}
+              value={formData.date}
+              onChange={date => setFormData({ ...formData, date: date })}
             />
           </Label>
           <Label>
             <Text>시작 시간</Text>
             <TimePicker
-              value={formData.startHour}
-              onChange={date => setFormData({ ...formData, startHour: date })}
+              value={formData.startTime}
+              onChange={date => setFormData({ ...formData, startTime: date })}
             />
           </Label>
           <Label>
@@ -54,7 +65,7 @@ const FormInterview = () => {
               type="number"
               placeholder="공고 제목을 입력하세요"
               value={formData.term}
-              onChange={e => setFormData({ ...formData, term: e.target.value })}
+              onChange={e => setFormData({ ...formData, term: +e.target.value })}
             />
           </Label>
           <Label>
@@ -62,16 +73,35 @@ const FormInterview = () => {
             <NumberInput
               type="number"
               placeholder="공고 제목을 입력하세요"
-              value={formData.count}
-              onChange={e => setFormData({ ...formData, count: e.target.value })}
+              value={formData.times}
+              onChange={e => setFormData({ ...formData, times: +e.target.value })}
             />
           </Label>
-          <AddButton>일정 추가</AddButton>
+          <AddButton onClick={handleAdd} type="button" className="btn">
+            일정 추가
+          </AddButton>
         </Field>
+        <Schedules>
+          {dataList.map((data, idx) => (
+            <Schecule key={`schedule${idx}`}>
+              <DataText>{getDateFormat(data.date)}</DataText>
+              <DataText>{getTimeFormat(data.startTime)}</DataText>
+              <DataText>{data.term}분 간격</DataText>
+              <DataText>{data.times}회 반복</DataText>
+              <IconButton type="button" className="delete" onClick={() => handleDelete(idx)}>
+                <RiDeleteBin6Line />
+              </IconButton>
+            </Schecule>
+          ))}
+        </Schedules>
       </Settings>
       <Buttons>
-        <CreateButton className="btn">일정 저장하기</CreateButton>
-        <NextButton className="btn">다음</NextButton>
+        <CreateButton className="btn" type="button" onClick={sendSchedule}>
+          일정 저장하기
+        </CreateButton>
+        <NextButton className="btn" type="button" onClick={clickNext}>
+          다음
+        </NextButton>
       </Buttons>
     </Form>
   );
@@ -90,6 +120,30 @@ const AddButton = styled.button`
   padding: 16px 32px;
   background-color: var(--sub-color);
   color: #fff;
+`;
+
+const Schedules = styled.div`
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  height: calc(100% - 132px);
+  padding: 16px 0;
+
+  &::-webkit-scrollbar {
+    display: none; /* Chrome , Safari , Opera */
+  }
+`;
+
+const Schecule = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+`;
+
+const DataText = styled.p`
+  font-size: 1.3rem;
+  font-weight: 500;
 `;
 
 export default FormInterview;

--- a/src/pages/Modal.tsx
+++ b/src/pages/Modal.tsx
@@ -1,36 +1,67 @@
 import styled from "styled-components";
 import { Container, SubTitle } from "../assets/style/Common";
-import { ModalType } from "./RecruitBoard";
 import { Controller } from "react-hook-form";
 import DatePicker from "react-datepicker";
 import { NavLink, Outlet, Params, useNavigate } from "react-router-dom";
 import { useEffect, useState } from "react";
-import { CreateButton, Form, Label } from "../assets/style/ScheduleFormStyle";
+import { CreateButton, Field, Form, Label, Text } from "../assets/style/ScheduleFormStyle";
 import { IoMdClose } from "react-icons/io";
+import { postInterviewParticipants, postInterviewSchedule } from "../axios/http/interview";
+import { ModalProps } from "../type/modal";
+import DatePickerOne from "../components/input/DatePickerOne";
+import TimePicker from "../components/input/TimePicker";
 
-interface ModalProps {
-  type: ModalType;
-  id?: Params;
-  step: string;
-  onClose: () => void;
-}
-
-const Modal = ({ type, id, step, onClose }: ModalProps) => {
+const Modal = ({ type, key, step, onClose }: ModalProps) => {
   const [emailText, setEmailText] = useState("");
+  const [typeEmail, setTypeEmail] = useState(false);
+  const [emailData, setEmailData] = useState({
+    endDate: new Date(),
+    endHour: new Date(2024, 7, 13, 18, 0),
+  });
   const navigate = useNavigate();
 
   useEffect(() => {
     navigate("/recruit-board/assignment");
+    type === "email" && setTypeEmail(true);
   }, [navigate]);
 
   const handleOnChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setEmailText(e.target.value);
   };
 
+  // 일정 저장하기 API
+  const sendSchedule = async () => {
+    const props = { jobPostingKey: key, stepId: step };
+    try {
+      await postInterviewParticipants(props);
+      await postInterviewSchedule(props);
+      alert("일정이 성공적으로 저장되었습니다.");
+    } catch (error) {
+      alert("일정 생성에 문제가 발생했습니다. 다시 시도해주세요.");
+    }
+  };
+
+  // 일정 생성 후, '다음' 클릭
+  const clickNext = () => {
+    const response = confirm("예약 메일로 넘어갑니다. 일정 생성을 완료하셨나요?");
+    if (response) {
+      setTypeEmail(true);
+    }
+  };
+
+  // 메일 예약하기
+  const sendEmail = async() => {
+    try {
+      await 
+    } catch (error) {
+      
+    }
+  }
+
   return (
     <Background>
       <Wrapper>
-        <ModalBox>
+        <ModalBox $type={typeEmail}>
           <ModalContainer>
             <SubTitle>일정 생성하기</SubTitle>
             <Tabs>
@@ -47,42 +78,39 @@ const Modal = ({ type, id, step, onClose }: ModalProps) => {
                 면접
               </Tab>
             </Tabs>
-            <Field>
-              <Outlet />
-            </Field>
+            <FormArea>
+              <Outlet context={{ sendSchedule, clickNext }} />
+            </FormArea>
           </ModalContainer>
           <ModalContainer>
             <SubTitle>예약 메일 발송하기</SubTitle>
             <Field>
               <Form>
-                <TextArea name="email" id="email" onChange={e => handleOnChange(e)}>
-                  {emailText}
-                </TextArea>
-                <Label htmlFor="date">날짜</Label>
-                <Label htmlFor="time">시간</Label>
-                {/* <Controller
-                  control={control}
-                  name="time"
-                  rules={{ required: "근무시간을 선택해주세요." }}
-                  defaultValue={new Date(2024, 7, 13, 9, 0)}
-                  render={({ field: { onChange, value } }) => (
-                    <TimePickerContainer>
-                      <DatePicker
-                        selected={value}
-                        onChange={date => onChange(date)}
-                        showTimeSelect
-                        showTimeSelectOnly
-                        timeIntervals={30}
-                        dateFormat="HH:mm"
-                        timeFormat="HH:mm"
-                        timeCaption=""
-                        customInput={<TimeInput />}
-                        disabled={freeHour}
-                      />
-                    </TimePickerContainer>
-                  )}
-                /> */}
-                <CreateButton className="btn">메일 예약하기</CreateButton>
+                <TextArea
+                  name="email"
+                  id="email"
+                  onChange={e => handleOnChange(e)}
+                  placeholder="일정은 자동으로 포함됩니다. 일정 외에 추가 전달사항이 있으시면 작성해주세요."
+                ></TextArea>
+                <Field>
+                  <Label>
+                    <Text>과제 마감 날짜</Text>
+                    <DatePickerOne
+                      value={emailData.endDate}
+                      onChange={date => setEmailData({ ...emailData, endDate: date })}
+                    />
+                  </Label>
+                  <Label>
+                    <Text>시간</Text>
+                    <TimePicker
+                      value={emailData.endHour}
+                      onChange={date => setEmailData({ ...emailData, endHour: date })}
+                    />
+                  </Label>
+                </Field>
+                <CreateButton className="btn" type="button" onClick={sendEmail}>
+                  메일 예약하기
+                </CreateButton>
               </Form>
             </Field>
           </ModalContainer>
@@ -130,11 +158,13 @@ const CloseButton = styled.button`
   color: #fff;
 `;
 
-const ModalBox = styled.div`
+const ModalBox = styled.div<{ $type: boolean }>`
   display: flex;
   flex-wrap: nowrap;
   width: 100%;
   height: 100%;
+  transition: all 0.5s;
+  transform: ${props => (props.$type ? "translateX(-100%)" : "translateX(0)")};
   h3 {
     color: #fff;
   }
@@ -166,11 +196,10 @@ const Tab = styled(NavLink)`
   &.active {
     background-color: var(--sub-color);
     color: #fff;
-    /* color: var(--primary-color); */
   }
 `;
 
-const Field = styled.div`
+const FormArea = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -180,6 +209,14 @@ const Field = styled.div`
   background-color: #fff;
 `;
 
-const TextArea = styled.textarea``;
+const TextArea = styled.textarea`
+  width: 95%;
+  height: 15rem;
+  padding: 16px;
+  border: 1px solid var(--border-gray-100);
+  border-radius: var(--button-radius);
+  resize: none;
+  font: inherit;
+`;
 
 export default Modal;

--- a/src/pages/RecruitBoard.tsx
+++ b/src/pages/RecruitBoard.tsx
@@ -6,14 +6,13 @@ import { useNavigate } from "react-router-dom";
 import { FaEnvelopeOpenText } from "react-icons/fa";
 import Modal from "./Modal";
 import { useParams } from "next/navigation";
+import { ModalType } from "../type/modal";
 
 interface ICandidateList {
   candidateKey: string;
   candidateName: string;
   createdAt: string;
 }
-
-export type ModalType = "email" | "schedule";
 
 const RecruitBoard = () => {
   // const param = useParams();
@@ -53,6 +52,7 @@ const RecruitBoard = () => {
     // fetchData();
   }, []);
 
+  // 칸반보드 1200px 넘어가면 양쪽으로 드래그
   let isDragging = false;
   let startX = 0;
   let scrollLeft = 0;
@@ -81,10 +81,12 @@ const RecruitBoard = () => {
     }
   };
 
+  // 이력서 보기
   const handleOpenResume = (key: string) => {
     navigate(`/view-resume/${key}`);
   };
 
+  // 지원자 선택하기
   const handleClickList = (stepKey: string) => {
     setActiveList(prevActiveList => {
       if (prevActiveList.length === 0) {
@@ -108,6 +110,7 @@ const RecruitBoard = () => {
     });
   };
 
+  // 모달 오픈
   const openModal = (type: ModalType, step: string) => {
     setModalType(type);
     setModalStep(step);
@@ -168,9 +171,9 @@ const RecruitBoard = () => {
                 </Step>
               ))}
             </Steps>
-            {/* <Modal type={modalType} id={param} /> */}
+            {/* <Modal type={modalType} key={param} /> */}
             {modal ? (
-              <Modal type={modalType} step={modalStep} onClose={() => setModal(false)} />
+              <Modal type={modalType} key={`id`} step={modalStep} onClose={() => setModal(false)} />
             ) : null}
           </Board>
         </Container>

--- a/src/type/interview.ts
+++ b/src/type/interview.ts
@@ -1,0 +1,16 @@
+export interface IInterviewProps {
+  jobPostingKey: string;
+  stepId: number;
+}
+
+export interface IInterviewData {
+  date: Date;
+  startTime: Date;
+  term: number;
+  times: number;
+}
+
+export interface SendScheduleConText {
+  sendSchedule: () => Promise<void>;
+  clickNext: () => void;
+}

--- a/src/type/modal.ts
+++ b/src/type/modal.ts
@@ -1,0 +1,8 @@
+export type ModalType = "email" | "schedule";
+
+export interface ModalProps {
+  type: ModalType;
+  key: string;
+  step: number;
+  onClose: () => void;
+}

--- a/src/utils/Format.ts
+++ b/src/utils/Format.ts
@@ -36,3 +36,16 @@ export const getDday = (endDate: string): string => {
     return `D${remainDate}`;
   }
 };
+
+/**
+ *
+ * @param time
+ * @returns `18:00`
+ */
+export const getTimeFormat = (time: Date) => {
+  return time.toLocaleTimeString("ko-KR", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+};


### PR DESCRIPTION
## 작업 내용

1. 일정생성 기능구현 (추가, 일정저장 API, 다음버튼 기능)
2. 예약메일 UI 완료 
3. time 포맷 추가

## 스크린샷
![image](https://github.com/user-attachments/assets/583c553d-03be-4647-8f29-840a2b8f362a)
![image](https://github.com/user-attachments/assets/c145f8a8-3a27-4f22-a18c-6f6fb8b423f3)
![image](https://github.com/user-attachments/assets/4e744726-9617-47e6-ac62-f97ef1b9febe)


## 리뷰 요구사항

일정 추가해서 모달창을 벗어나면 리스트 부분만 스크롤되게 구현했습니다
추가/삭제는 맘대로 할 수 있고, 일정 저장하기를 누르면 API로 post 합니다
다음 버튼을 누르면 alert으로 일정을 완료했는지 물어보고, 메일로 넘어갑니다
메일에서는 뒤로 가기가 불가능하고 예약만 가능합니다.
(메일 API가 미완성이라 여기까지만 먼저 올리겠습니당)

close #69
