### PR TITLE
로그인 토큰 저장

### DIFF
--- a/src/axios/instances.ts
+++ b/src/axios/instances.ts
@@ -15,14 +15,35 @@ export interface HttpClient extends AxiosInstance {
 
 export const http: HttpClient = axiosInstance;
 axiosInstance.interceptors.response.use(
-  response => response.data,
+  response => {
+    // 인증 토큰이 있다면 로컬스토리지에 저장
+    console.log(response);
+
+    if (response.headers["authorization"]) {
+      localStorage.setItem("token", `${response.headers["authorization"]}`);
+      console.log(response.headers["authorization"]);
+    }
+
+    return response.data;
+  },
   error => {
     console.log(error);
     return Promise.reject(error);
   },
 );
 
-axiosInstance.interceptors.request.use(req => {
-  //TODO: auth있으면 헤더에 넣기
-  return req;
-});
+axiosInstance.interceptors.request.use(
+  //auth있으면 헤더에 넣기
+  config => {
+    const token = localStorage.getItem("token");
+    if (token) {
+      config.headers.Authorization = `${token}`;
+    }
+    console.log(config);
+
+    return config;
+  },
+  req => {
+    return req;
+  },
+);

--- a/src/axios/instances.ts
+++ b/src/axios/instances.ts
@@ -17,11 +17,8 @@ export const http: HttpClient = axiosInstance;
 axiosInstance.interceptors.response.use(
   response => {
     // 인증 토큰이 있다면 로컬스토리지에 저장
-    console.log(response);
-
     if (response.headers["authorization"]) {
       localStorage.setItem("token", `${response.headers["authorization"]}`);
-      console.log(response.headers["authorization"]);
     }
 
     return response.data;
@@ -39,7 +36,6 @@ axiosInstance.interceptors.request.use(
     if (token) {
       config.headers.Authorization = `${token}`;
     }
-    console.log(config);
 
     return config;
   },

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -3,7 +3,6 @@ import styled from "styled-components";
 import { HiArrowLeftOnRectangle } from "react-icons/hi2";
 import { IoPersonCircleOutline, IoSettings } from "react-icons/io5";
 import { FaKey } from "react-icons/fa6";
-import axios from "axios";
 import { useRecoilState } from "recoil";
 import { authUserState } from "../../recoil/store";
 import { IoIosLock } from "react-icons/io";
@@ -18,6 +17,7 @@ const Header = () => {
       try {
         // await axios.post("/common/signout");
         setAuthUser(null);
+        localStorage.removeItem("token");
         navigate("/");
       } catch (error) {
         alert("로그아웃 중 문제가 발생했습니다. 다시 시도해주세요.");

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -54,9 +54,8 @@ const Index = () => {
           endDate: "2024-08-02",
         },
       ]);
-
-      const response = await getJobPostings();
-      setJobInfos(response);
+      // const response = await getJobPostings();
+      // setJobInfos(response);
     })();
   }, []);
 


### PR DESCRIPTION
## 작업 내용

1. instance에서 헤더로 인증토큰이 오면 저장하도록 했습니다.

```
    if (response.headers["authorization"]) {
      localStorage.setItem("token", `${response.headers["authorization"]}`);
      console.log(response.headers["authorization"]);
    }
```

2. 로그아웃 할 때 로컬스토리지를 삭제했습니다.
```
        localStorage.removeItem("token");
```


3. 요청보낼때 토큰이 저장되어있다면 헤더에 포함하도록 했습니다.

```
  config => {
    const token = localStorage.getItem("token");
    if (token) {
      config.headers.Authorization = `${token}`;
    }

    return config;
  },
```

## 리뷰 요구사항
아직 api 해볼수있는게 없어서 제대로 테스트는 못했습니다. 혹시 하다가 오류생기면 말슴해주세요.

## 연관된 이슈

close #78 
