### PR TITLE
[회사] 마이페이지 API 구현 및 회사정보 로직 수정

### DIFF
--- a/src/assets/style/MypageStyle.ts
+++ b/src/assets/style/MypageStyle.ts
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import styled from "styled-components";
 
 export const Top = styled.div`
@@ -29,7 +30,7 @@ export const InfoDesc = styled.p`
   width: calc(100% - 150px);
 `;
 
-export const RecruitLists = styled.ul`
+export const RecruitLists = styled.div`
   display: flex;
   flex-direction: column;
   padding: 16px 32px;
@@ -37,7 +38,7 @@ export const RecruitLists = styled.ul`
   border-radius: var(--box-radius);
 `;
 
-export const RecruitList = styled.li`
+export const RecruitList = styled(Link)`
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -66,13 +67,15 @@ export const Dday = styled.p``;
 
 export const ListTitle = styled.h4`
   width: 100%;
-  max-width: 450px;
+  max-width: 350px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 `;
 
-export const ListCareer = styled.p``;
+export const ListCareer = styled.p`
+  font-weight: 500;
+`;
 
 export const ListStep = styled.p`
   flex-shrink: 0;

--- a/src/axios/http/company.ts
+++ b/src/axios/http/company.ts
@@ -1,0 +1,14 @@
+import { CompanyInfo } from "../../type/company";
+import { http } from "../instances";
+
+export const getCompanyInfo = (companyKey: string) => {
+  return http.get<CompanyInfo>(`/companies/${companyKey}/information`);
+};
+
+export const postCompanyInfo = (companyKey: string, body: CompanyInfo) => {
+  return http.post<CompanyInfo>(`/companies/${companyKey}/information`, body);
+};
+
+export const putCompanyInfo = (companyKey: string, body: CompanyInfo) => {
+  return http.put<CompanyInfo>(`/companies/${companyKey}/information`, body);
+};

--- a/src/axios/http/jobPosting.ts
+++ b/src/axios/http/jobPosting.ts
@@ -1,11 +1,16 @@
 import { AxiosRequestConfig } from "axios";
-import { companyInfo } from "../../../type/company";
-import { JobInfo, JobPosting, JobPostingList } from "../../../type/jobPosting";
+import { companyInfo, PostedJobPoting } from "../../type/company";
+import { JobInfo, JobPosting, JobPostingList } from "../../type/jobPosting";
 import { http } from "../instances";
 
 // 전체 공고 조회
 export const getJobPostings = () => {
   return http.get<JobInfo[]>(`common/job-postings`);
+};
+
+// 회사 마이페이지 공고 조회
+export const getPostedJobPostings = (companyKey: string) => {
+  return http.get<PostedJobPoting[]>(`common/${companyKey}/posted-job-postings`);
 };
 
 export const postCompaniesJobPosting = (

--- a/src/pages/Modal.tsx
+++ b/src/pages/Modal.tsx
@@ -48,13 +48,12 @@ const Modal = ({ type, key, step, onClose }: ModalProps) => {
   };
 
   // 메일 예약하기
-  // const sendEmail = async() => {
-  //   try {
-  //     await
-  //   } catch (error) {
-
-  //   }
-  // }
+  const sendEmail = async () => {
+    // try {
+    //   await
+    // } catch (error) {
+    // }
+  };
 
   return (
     <Background>

--- a/src/pages/Modal.tsx
+++ b/src/pages/Modal.tsx
@@ -1,8 +1,6 @@
 import styled from "styled-components";
 import { Container, SubTitle } from "../assets/style/Common";
-import { Controller } from "react-hook-form";
-import DatePicker from "react-datepicker";
-import { NavLink, Outlet, Params, useNavigate } from "react-router-dom";
+import { NavLink, Outlet, useNavigate } from "react-router-dom";
 import { useEffect, useState } from "react";
 import { CreateButton, Field, Form, Label, Text } from "../assets/style/ScheduleFormStyle";
 import { IoMdClose } from "react-icons/io";
@@ -23,7 +21,7 @@ const Modal = ({ type, key, step, onClose }: ModalProps) => {
   useEffect(() => {
     navigate("/recruit-board/assignment");
     type === "email" && setTypeEmail(true);
-  }, [navigate]);
+  }, [navigate, type]);
 
   const handleOnChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setEmailText(e.target.value);
@@ -50,13 +48,13 @@ const Modal = ({ type, key, step, onClose }: ModalProps) => {
   };
 
   // 메일 예약하기
-  const sendEmail = async() => {
-    try {
-      await 
-    } catch (error) {
-      
-    }
-  }
+  // const sendEmail = async() => {
+  //   try {
+  //     await
+  //   } catch (error) {
+
+  //   }
+  // }
 
   return (
     <Background>
@@ -91,6 +89,7 @@ const Modal = ({ type, key, step, onClose }: ModalProps) => {
                   id="email"
                   onChange={e => handleOnChange(e)}
                   placeholder="일정은 자동으로 포함됩니다. 일정 외에 추가 전달사항이 있으시면 작성해주세요."
+                  value={emailText}
                 ></TextArea>
                 <Field>
                   <Label>

--- a/src/type/company.ts
+++ b/src/type/company.ts
@@ -1,8 +1,20 @@
-export interface companyInfo {
+export interface CompanyInfo {
   companyInfoKey: string;
   employees: number;
   companyAge: Date;
   companyUrl: string;
   boss: string;
   address: string;
+}
+
+export interface PostedJobPoting {
+  jobPostingKey: string;
+  title: string;
+  career: string;
+  endDateTime: string;
+}
+
+export interface InfoItem {
+  title: string;
+  desc: string | number | Date;
 }


### PR DESCRIPTION
## 작업 내용

1. [회사] 마이페이지 회사정보/채용공고목록 API 구현
2. 회사정보 input 및 컴포넌트 수정
3. 채용공고목록에 채용단계 버튼 추가
4. companyInfo 타입 이름 수정

## 스크린샷
![image](https://github.com/user-attachments/assets/fabe52b1-8f9f-47a5-afc5-fef475e6a993)

## 리뷰 요구사항

회사정보 로직을 바꾸었는데 테스트해보고 수정해야할 것 같습니다
companyInfo 타입이름이 카멜케이스로 되어있어서 제가 파스칼케이스로 바꾸었는데
아마 지윤님이 jobPosting 컴포넌트에서 사용하신 것 같아요, 제가 다 수정하기는 위험해서 pull 받으시면 수정 부탁드립니다 !

## 연관된 이슈
api가 안되어서 테스트를 못해봤습니다.. 일단 구현만 해두었고 명세서 확정나면 다시 하겠습니당

close #82
