### PR TITLE
채용단계 렌더링 시 필요한 데이터 API 호출, 데이터 타입 확정 / 모달창 경로 및 props 전달

### DIFF
--- a/src/axios/http/recruitBoard.ts
+++ b/src/axios/http/recruitBoard.ts
@@ -1,7 +1,7 @@
-import { IStep } from "../../type/recruitBoard";
+import { RecruitBoardData } from "../../type/recruitBoard";
 import { http } from "../instances";
 
-// todo: 정보 한번에 받아오는걸로 API 수정중
-export const getSteps = (jobPostingKey: string) => {
-  return http.get<IStep[]>(`/job-postings/{jobPostingKey}/steps`);
+// recruit-board 페이지 정보 한 번에 불러오기
+export const getRecruitBoardData = (jobPostingKey: string) => {
+  return http.get<RecruitBoardData[]>(`/job-postings/${jobPostingKey}/candidates-list`);
 };

--- a/src/pages/CompanyMypage.tsx
+++ b/src/pages/CompanyMypage.tsx
@@ -82,7 +82,7 @@ const CompanyMypage = () => {
     const fetchJobPosting = async () => {
       try {
         const response = await getPostedJobPostings(authUser.key);
-        console.log(response);
+
         setJobPostingList(response);
       } catch (error) {
         alert("채용공고 목록을 불러오는데 문제가 생겼습니다.");

--- a/src/pages/CompanyMypage.tsx
+++ b/src/pages/CompanyMypage.tsx
@@ -157,7 +157,7 @@ const CompanyMypage = () => {
   return (
     <Wrapper>
       <Inner className="inner-1200">
-        <UserName>{"(주)회사 이름"}</UserName>
+        <UserName>{authUser?.name}</UserName>
         <Container>
           <Top>
             <SubTitle>회사 정보</SubTitle>
@@ -223,7 +223,10 @@ const CompanyMypage = () => {
                 <ListCareer>
                   {jobPosting.career === 0 ? "신입" : jobPosting.career + "년 이상"}
                 </ListCareer>
-                <StepsButton to={`/recruit-board/${jobPosting.jobPostingKey}`}>
+                <StepsButton
+                  to={`/recruit-board/${jobPosting.jobPostingKey}`}
+                  state={{ title: jobPosting.title }}
+                >
                   채용단계 관리
                 </StepsButton>
               </RecruitList>

--- a/src/pages/Modal.tsx
+++ b/src/pages/Modal.tsx
@@ -10,6 +10,7 @@ import DatePickerOne from "../components/input/DatePickerOne";
 import TimePicker from "../components/input/TimePicker";
 
 const Modal = ({ type, key, step, onClose }: ModalProps) => {
+  console.log(key);
   const [emailText, setEmailText] = useState("");
   const [typeEmail, setTypeEmail] = useState(false);
   const [emailData, setEmailData] = useState({
@@ -19,7 +20,6 @@ const Modal = ({ type, key, step, onClose }: ModalProps) => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    navigate("/recruit-board/assignment");
     type === "email" && setTypeEmail(true);
   }, [navigate, type]);
 
@@ -65,13 +65,13 @@ const Modal = ({ type, key, step, onClose }: ModalProps) => {
             <SubTitle>일정 생성하기</SubTitle>
             <Tabs>
               <Tab
-                to="/recruit-board/assignment"
+                to={`/recruit-board/${key}/assignment`}
                 className={({ isActive }) => (isActive ? "active" : "")}
               >
                 과제
               </Tab>
               <Tab
-                to="/recruit-board/interview"
+                to={`/recruit-board/${key}/interview`}
                 className={({ isActive }) => (isActive ? "active" : "")}
               >
                 면접

--- a/src/pages/RecruitBoard.tsx
+++ b/src/pages/RecruitBoard.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import { Container, FullBtn, Inner, SubTitle, UserName, Wrapper } from "../assets/style/Common";
 import { useEffect, useRef, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { FaEnvelopeOpenText } from "react-icons/fa";
 import Modal from "./Modal";
 import { ModalType } from "../type/modal";
@@ -9,6 +9,8 @@ import { RiDeleteBin6Line } from "react-icons/ri";
 import { deleteInterviewSchedule } from "../axios/http/interview";
 import { CandidateInfo, RecruitBoardData } from "../type/recruitBoard";
 import { getRecruitBoardData } from "../axios/http/recruitBoard";
+import { useRecoilValue } from "recoil";
+import { authUserState } from "../recoil/store";
 
 const RecruitBoard = () => {
   const { jobPostingKey } = useParams();
@@ -27,6 +29,8 @@ const RecruitBoard = () => {
   const [modalStep, setModalStep] = useState<number>(0);
   const navigate = useNavigate();
   const containerRef = useRef<HTMLDivElement>(null);
+  const authUser = useRecoilValue(authUserState);
+  const location = useLocation();
 
   // 단계 및 지원자 목록, 일정 정보
   useEffect(() => {
@@ -93,6 +97,7 @@ const RecruitBoard = () => {
     setModalType(type);
     setModalStep(step);
     setModal(true);
+    navigate(`/recruit-board/${jobPostingKey}/assignment`);
   };
 
   // 이력서 보기
@@ -156,9 +161,9 @@ const RecruitBoard = () => {
   return (
     <Wrapper>
       <Inner className="inner-1200">
-        <UserName>{"(주)회사 이름"}</UserName>
+        <UserName>{authUser?.name}</UserName>
         <Container>
-          <SubTitle>{"[FE] 신입사원 채용"}</SubTitle>
+          <SubTitle>{location.state.title}</SubTitle>
           <Board
             ref={containerRef}
             onMouseDown={handleMouseDown}
@@ -217,8 +222,8 @@ const RecruitBoard = () => {
                 </Step>
               ))}
             </Steps>
-            {modal && (
-              <Modal type={modalType} key={`${jobPostingKey}`} step={modalStep} onClose={onClose} />
+            {jobPostingKey && modal && (
+              <Modal type={modalType} key={jobPostingKey} step={modalStep} onClose={onClose} />
             )}
           </Board>
         </Container>

--- a/src/route/Router.tsx
+++ b/src/route/Router.tsx
@@ -94,7 +94,6 @@ const router = createBrowserRouter([
         ),
         children: [
           {
-            index: true,
             path: "assignment",
             element: (
               <ProtectedRoute>

--- a/src/type/recruitBoard.ts
+++ b/src/type/recruitBoard.ts
@@ -1,10 +1,13 @@
-export interface ICandidate {
-  candidateKey: string;
-  candidateName: string;
-  createdAt: string;
-}
-
-export interface IStep {
+export interface RecruitBoardData {
   stepId: number;
   stepName: string;
+  candidateTechStackInterviewInfoDtoList: CandidateInfo[];
+}
+
+export interface CandidateInfo {
+  candidateKey: string;
+  candidateName: string;
+  resumeKey: string;
+  techStack: string[];
+  scheduleDateTime: string | null;
 }


### PR DESCRIPTION
## 작업 내용

1. 채용단계 정보 불러오기 API 연동
2. response 데이터 타입 확정(stepName을 포함해주시기로 했습니다) / 배포버전에 적용은 아직..
3. 모달창 경로를 key값에 맞게 변경
4. 회사이름, 공고제목 등은 recoil 값이랑 mypage에서 넘겨준 props로 전달

## 스크린샷
![image](https://github.com/user-attachments/assets/de8bee28-250d-4092-858e-b177ab17bf3f)


## 리뷰 요구사항

아직 stepName이 응답에 없어서 단계 이름은 안나오는게 맞습니당
지금 확인해보니 공고제목을 받아온 뒤로 모달창이 안열리네요 하하
내일 PR때 해결해서 올리겠습니다 !


close #105
