### PR TITLE
과제/면접 일정 API 완 !

### DIFF
--- a/src/assets/style/input.ts
+++ b/src/assets/style/input.ts
@@ -56,9 +56,10 @@ export const DataPickerInput = styled.input`
   font-size: 1rem;
 
   &:disabled {
-    border: 1px solid var(--bg-light-gray);
-    color: var(--bg-light-gray);
+    border: 1px solid var(--border-gray-100);
+    color: var(--border-gray-100);
     background-color: #f8f8f8;
+    cursor: auto;
   }
 `;
 

--- a/src/axios/http/interview.ts
+++ b/src/axios/http/interview.ts
@@ -1,18 +1,49 @@
-import { IInterviewProps } from "../../type/interview";
+import {
+  AssignmentScheduleBody,
+  IInterviewProps,
+  InterviewScheduleBody,
+  InterviewScheduleKey,
+} from "../../type/interview";
 import { http } from "../instances";
 
 export const getInterviewSchedule = (props: IInterviewProps) => {
   return http.get(`/job-postings/${props.jobPostingKey}/steps/${props.stepId}/interview-schedule`);
 };
 
-export const postInterviewParticipants = (props: IInterviewProps) => {
+export const postAssignmentSchedule = (props: IInterviewProps, body: AssignmentScheduleBody) => {
   return http.post(
-    `/job-postings/${props.jobPostingKey}/steps/${props.stepId}/interview-schedule-participants`,
+    `/job-postings/${props.jobPostingKey}/steps/${props.stepId}/task-schedule`,
+    body,
+    {
+      headers: {
+        "Content-Type": "application/json",
+      },
+    },
   );
 };
 
-export const postInterviewSchedule = (props: IInterviewProps) => {
-  return http.post(`/job-postings/${props.jobPostingKey}/steps/${props.stepId}/interview-schedule`);
+export const postInterviewSchedule = (props: IInterviewProps, body: InterviewScheduleBody) => {
+  return http.post<InterviewScheduleKey>(
+    `/job-postings/${props.jobPostingKey}/steps/${props.stepId}/interview-schedule`,
+    body,
+    {
+      headers: {
+        "Content-Type": "application/json",
+      },
+    },
+  );
+};
+
+export const postInterviewParticipants = (props: IInterviewProps, body: InterviewScheduleBody) => {
+  return http.post(
+    `/job-postings/${props.jobPostingKey}/steps/${props.stepId}/interview-schedule-participants`,
+    body,
+    {
+      headers: {
+        "Content-Type": "application/json",
+      },
+    },
+  );
 };
 
 export const deleteInterviewSchedule = (props: IInterviewProps) => {

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import { Container, SubTitle } from "../assets/style/Common";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
 import { CreateButton, Field, Form, Label, Text } from "../assets/style/ScheduleFormStyle";
 import { IoMdClose } from "react-icons/io";
@@ -9,7 +9,8 @@ import DatePickerOne from "./input/DatePickerOne";
 import TimePicker from "./input/TimePicker";
 import FormContent from "./FormContent";
 
-const Modal = ({ type, key, step, onClose }: ModalProps) => {
+const Modal = ({ type, step, onClose }: ModalProps) => {
+  const { jobPostingKey } = useParams();
   const [currentTab, setCurrentTab] = useState("assignment");
   const [emailText, setEmailText] = useState("");
   const [typeEmail, setTypeEmail] = useState(false);
@@ -17,6 +18,7 @@ const Modal = ({ type, key, step, onClose }: ModalProps) => {
     endDate: new Date(),
     endHour: new Date(2024, 7, 13, 18, 0),
   });
+  const [scheduleKey, setScheduleKey] = useState("");
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -60,12 +62,15 @@ const Modal = ({ type, key, step, onClose }: ModalProps) => {
               </Tab>
             </Tabs>
             <FormArea>
-              <FormContent
-                currentTab={currentTab}
-                jobPostingKey={key}
-                stepId={step}
-                setTypeEmail={setTypeEmail}
-              />
+              {jobPostingKey && (
+                <FormContent
+                  currentTab={currentTab}
+                  jobPostingKey={jobPostingKey}
+                  stepId={step}
+                  setTypeEmail={setTypeEmail}
+                  setScheduleKey={setScheduleKey}
+                />
+              )}
             </FormArea>
           </ModalContainer>
           <ModalContainer>

--- a/src/pages/RecruitBoard.tsx
+++ b/src/pages/RecruitBoard.tsx
@@ -245,15 +245,15 @@ const RecruitBoard = () => {
                   <StepHead>
                     <StepTitle className="sub-title">{data.stepName}</StepTitle>
                     {data.stepName !== "서류전형" &&
-                    data.candidateTechStackInterviewInfoDtoList.length ? (
-                      <RemoveBtn onClick={() => handleRemoveSchedule(data.stepId)}>
-                        <span>일정 삭제</span>
-                        <RiDeleteBin6Line />
-                      </RemoveBtn>
-                    ) : null}
+                      !!data.candidateTechStackInterviewInfoDtoList.length && (
+                        <RemoveBtn onClick={() => handleRemoveSchedule(data.stepId)}>
+                          <span>일정 삭제</span>
+                          <RiDeleteBin6Line />
+                        </RemoveBtn>
+                      )}
                   </StepHead>
                   {data.stepName === "서류전형" ? null : data.candidateTechStackInterviewInfoDtoList
-                      .length ? (
+                      .length > 0 ? (
                     <EmailBtn onClick={() => openModal("email", idx + 1)}>
                       예약 메일 발송하기
                     </EmailBtn>

--- a/src/pages/RecruitBoard.tsx
+++ b/src/pages/RecruitBoard.tsx
@@ -245,12 +245,12 @@ const RecruitBoard = () => {
                   <StepHead>
                     <StepTitle className="sub-title">{data.stepName}</StepTitle>
                     {data.stepName !== "서류전형" &&
-                      data.candidateTechStackInterviewInfoDtoList.length && (
-                        <RemoveBtn onClick={() => handleRemoveSchedule(data.stepId)}>
-                          <span>일정 삭제</span>
-                          <RiDeleteBin6Line />
-                        </RemoveBtn>
-                      )}
+                    data.candidateTechStackInterviewInfoDtoList.length ? (
+                      <RemoveBtn onClick={() => handleRemoveSchedule(data.stepId)}>
+                        <span>일정 삭제</span>
+                        <RiDeleteBin6Line />
+                      </RemoveBtn>
+                    ) : null}
                   </StepHead>
                   {data.stepName === "서류전형" ? null : data.candidateTechStackInterviewInfoDtoList
                       .length ? (

--- a/src/type/interview.ts
+++ b/src/type/interview.ts
@@ -3,8 +3,24 @@ export interface IInterviewProps {
   stepId: number;
 }
 
+export interface AssignmentScheduleBody {
+  endDate: string;
+}
+
+export interface InterviewScheduleBody {
+  startDate: string;
+  startTime: string;
+  term: number;
+  times: number;
+}
+[];
+
+export interface InterviewScheduleKey {
+  interviewScheduleKey: string;
+}
+
 export interface IInterviewData {
-  date: Date;
+  startDate: Date;
   startTime: Date;
   term: number;
   times: number;

--- a/src/type/modal.ts
+++ b/src/type/modal.ts
@@ -2,7 +2,6 @@ export type ModalType = "email" | "schedule";
 
 export interface ModalProps {
   type: ModalType;
-  key: string;
   step: number;
   onClose: () => void;
 }


### PR DESCRIPTION
## 작업 내용

1. 과제/면접 일정 생성 API
2. 일정 삭제 API도 되어있으나 일정이 아직 생성되지 않아서 테스트X

## 스크린샷
![image](https://github.com/user-attachments/assets/b44efa49-def8-40e2-b6e7-2b03fbb7307b)


## 리뷰 요구사항

시간은 default 값으로 23:59이 들어가서 disabled 처리했습니다
근데 글씨가 너무안보여서 disabled의 color 색을 바꿨어요,,
과제/면접 일정은 마감날짜가 지나야 생성이 가능하다고 합니다..
이력서도 완료되어야 지원할 수 있어서 테스트는 못해봤어요ㅠ

## 연관된 이슈

schedule 을 useState로 일정만 추출해서 업데이트해주고 일정이 있으면 [일정삭제]가 보이고 [일정생성] 버튼이 안보여야하는데 schedule을 배열로 취급하면 자꾸 오류가 나네요.. 도저히 해결이 안되어서 일단 조건문 빼버리고 올렸습니다!

close #116
