### PR TITLE
지원자들 단계 넘기기 API 및 상세 로직

### DIFF
--- a/src/axios/http/recruitBoard.ts
+++ b/src/axios/http/recruitBoard.ts
@@ -1,7 +1,12 @@
-import { RecruitBoardData } from "../../type/recruitBoard";
+import { NextStepBody, RecruitBoardData } from "../../type/recruitBoard";
 import { http } from "../instances";
 
 // recruit-board 페이지 정보 한 번에 불러오기
 export const getRecruitBoardData = (jobPostingKey: string) => {
   return http.get<RecruitBoardData[]>(`/job-postings/${jobPostingKey}/candidates-list`);
+};
+
+// 지원자들 다음 단계로 넘기기
+export const putNextStep = (jobPostingKey: string, body: NextStepBody) => {
+  return http.put(`/job-postings/${jobPostingKey}/edit-step`, body);
 };

--- a/src/pages/RecruitBoard.tsx
+++ b/src/pages/RecruitBoard.tsx
@@ -8,7 +8,7 @@ import { ModalType } from "../type/modal";
 import { RiDeleteBin6Line } from "react-icons/ri";
 import { deleteInterviewSchedule } from "../axios/http/interview";
 import { CandidateInfo, RecruitBoardData } from "../type/recruitBoard";
-import { getRecruitBoardData } from "../axios/http/recruitBoard";
+import { getRecruitBoardData, putNextStep } from "../axios/http/recruitBoard";
 import { useRecoilValue } from "recoil";
 import { authUserState } from "../recoil/store";
 
@@ -18,6 +18,7 @@ const RecruitBoard = () => {
   const [currentStep, setCurrentStep] = useState(1);
   const [schedule, setSchedule] = useState<(string | null)[][]>([]);
   const [activeList, setActiveList] = useState<CandidateInfo[]>([]);
+  const [activeStep, setActiveStep] = useState<number>(1);
   const [modal, setModal] = useState(false);
   const [modalType, setModalType] = useState<ModalType>("schedule");
   const [modalStep, setModalStep] = useState<number>(0);
@@ -41,6 +42,7 @@ const RecruitBoard = () => {
 
   // 단계 및 지원자 목록, 일정 정보
   useEffect(() => {
+    console.log(currentStep);
     if (!jobPostingKey) return;
     console.log(schedule[0]);
 
@@ -118,49 +120,70 @@ const RecruitBoard = () => {
   };
 
   // 지원자 선택하기
-  const handleClickList = (candidate: CandidateInfo) => {
-    setActiveList(prevActiveList => {
-      if (prevActiveList.length === 0) {
-        return [candidate];
+  const handleClickList = (candidate: CandidateInfo, step: number) => {
+    setActiveStep(prevStep => {
+      // 동일한 step의 지원자를 클릭했는지 체크
+      if (prevStep !== step) {
+        const ok = confirm(
+          "현재 다른 단계에서 선택중인 지원자가 있습니다. 클릭하신 단계의 지원자를 선택하시겠어요?",
+        );
+        // 다른 단계를 선택하면 activeList 초기화
+        if (ok) {
+          setActiveList([candidate]);
+          return step;
+        }
+        return prevStep;
+      } else {
+        // 같은 단계를 선택하면 activeList 업데이트
+        setActiveList(prevActiveList => {
+          if (prevActiveList.length === 0) {
+            return [candidate];
+          }
+
+          return prevActiveList.includes(candidate)
+            ? prevActiveList.filter(item => item !== candidate)
+            : [...prevActiveList, candidate];
+        });
       }
-
-      //todo: 동일한 step의 지원자를 클릭했는지 검사할지?
-      return prevActiveList.includes(candidate)
-        ? prevActiveList.filter(item => item !== candidate)
-        : [...prevActiveList, candidate];
-
-      // const ok = confirm(
-      //   "현재 다른 단계에서 선택중인 지원자가 있습니다. 클릭하신 단계의 지원자를 선택하시겠어요?",
-      // );
-
-      // if (ok) {
-      //   return [stepName];
-      // }
-      // return prevActiveList;
+      return step;
     });
   };
 
   // 다음 단계로 넘기기
-  const handleNexteStep = () => {
+  const handleNexteStep = async (stepId: number) => {
+    if (!jobPostingKey) return;
+
     if (currentStep < dataList.length) {
       const activeCandidates = activeList;
       const inactiveCandidates = dataList[
         currentStep - 1
       ].candidateTechStackInterviewInfoDtoList.filter(candidate => !activeList.includes(candidate));
+      const activeCandidateKeys = activeCandidates.map(candidate => candidate.candidateKey);
 
-      setDataList(prev => {
-        const newCandidateList = [...prev];
-        newCandidateList[currentStep - 1].candidateTechStackInterviewInfoDtoList =
-          inactiveCandidates;
-        newCandidateList[currentStep].candidateTechStackInterviewInfoDtoList = [
-          ...newCandidateList[currentStep].candidateTechStackInterviewInfoDtoList,
-          ...activeCandidates,
-        ];
-        return newCandidateList;
-      });
+      const nextStepBody = {
+        currentStepId: currentStep,
+        candidateKeys: [...activeCandidateKeys],
+      };
 
-      setActiveList([]);
-      setCurrentStep(prev => prev + 1);
+      try {
+        await putNextStep(jobPostingKey, nextStepBody);
+
+        setDataList(prev => {
+          const newCandidateList = [...prev];
+          newCandidateList[currentStep - 1].candidateTechStackInterviewInfoDtoList =
+            inactiveCandidates;
+          newCandidateList[currentStep].candidateTechStackInterviewInfoDtoList = [
+            ...newCandidateList[currentStep].candidateTechStackInterviewInfoDtoList,
+            ...activeCandidates,
+          ];
+          return newCandidateList;
+        });
+
+        setActiveList([]);
+        setCurrentStep(prev => prev + 1);
+      } catch (error) {
+        alert("단계를 넘기는데 문제가 생겼습니다. 다시 시도해주세요.");
+      }
     }
   };
 
@@ -210,7 +233,7 @@ const RecruitBoard = () => {
                       <List
                         key={candidate.candidateKey}
                         $isActive={activeList.includes(candidate)}
-                        onClick={() => handleClickList(candidate)}
+                        onClick={() => handleClickList(candidate, idx + 1)}
                       >
                         <Name>{candidate.candidateName}</Name>
                         <Skills>
@@ -229,9 +252,14 @@ const RecruitBoard = () => {
                       </List>
                     ))}
                   </Lists>
-                  {idx + 1 === currentStep && activeList.length && idx + 1 !== dataList.length && (
-                    <PassBtn onClick={handleNexteStep}>다음 단계로 넘기기</PassBtn>
-                  )}
+                  {/* 현재 단계이고, 선택된 지원자가 있고, 마지막 단계가 아닐 경우 */}
+                  {idx + 1 === currentStep &&
+                    activeList.length > 0 &&
+                    idx + 1 !== dataList.length && (
+                      <PassBtn onClick={() => handleNexteStep(data.stepId)}>
+                        다음 단계로 넘기기
+                      </PassBtn>
+                    )}
                 </Step>
               ))}
             </Steps>

--- a/src/pages/RecruitBoard.tsx
+++ b/src/pages/RecruitBoard.tsx
@@ -124,14 +124,7 @@ const RecruitBoard = () => {
     setActiveStep(prevStep => {
       // 동일한 step의 지원자를 클릭했는지 체크
       if (prevStep !== step) {
-        const ok = confirm(
-          "현재 다른 단계에서 선택중인 지원자가 있습니다. 클릭하신 단계의 지원자를 선택하시겠어요?",
-        );
-        // 다른 단계를 선택하면 activeList 초기화
-        if (ok) {
-          setActiveList([candidate]);
-          return step;
-        }
+        alert("현재 단계에서만 선택하실 수 있습니다.");
         return prevStep;
       } else {
         // 같은 단계를 선택하면 activeList 업데이트
@@ -161,7 +154,7 @@ const RecruitBoard = () => {
       const activeCandidateKeys = activeCandidates.map(candidate => candidate.candidateKey);
 
       const nextStepBody = {
-        currentStepId: currentStep,
+        currentStepId: stepId,
         candidateKeys: [...activeCandidateKeys],
       };
 

--- a/src/type/recruitBoard.ts
+++ b/src/type/recruitBoard.ts
@@ -17,3 +17,8 @@ export interface CandidateInfo {
   techStack: string[];
   scheduleDateTime: string | null;
 }
+
+export interface NextStepBody {
+  currentStepId: number;
+  candidateKeys: string[];
+}


### PR DESCRIPTION
## 작업 내용

1. 지원자들 단계 넘기기 API 
2. 같은 단계의 지원자들인지 체크 
3. 이미 클릭한 지원자면 클릭 해제
4. 기존 지원자들과 다른 단계를 클릭하면 alert 띄워주고 현재 단계만 선택하도록 알림
(원래는 다른 단계를 선택하도록 이동시켜줬는데, 일정이 생성되고도 마구 바뀌면 안될 것 같아서 수정했습니다)

## 리뷰 요구사항

음.. 단계 넘기는게 제일 어렵네요 로직 짜는게 어려웠습니다..
api는 명세서랑 respnse에서 요구하는 key값이 달라서 질문 올렸습니당


close #126
