### PR TITLE
feat: 자율출근제 상수로, 무한스크롤

### DIFF
--- a/src/constants/Word.ts
+++ b/src/constants/Word.ts
@@ -1,0 +1,2 @@
+// 자유출근제
+export const FREE_HOUR = "자유출근제";

--- a/src/pages/CreateJobPost.tsx
+++ b/src/pages/CreateJobPost.tsx
@@ -13,6 +13,7 @@ import TimePicker from "../components/input/TimePicker";
 import { useRecoilValue } from "recoil";
 import { authUserState } from "../recoil/store";
 import { optionEducation, optionEmploymentType, optionJob, techStacks } from "../constants/options";
+import { FREE_HOUR } from "../constants/Word";
 
 interface JobPostingForm {
   jobCategory: string;
@@ -112,7 +113,7 @@ const CreateJobPost = () => {
       if (jobPostingInfo.career != -1) inputMemory.current.career = jobPostingInfo.career;
       if (jobPostingInfo.salary != -1) inputMemory.current.salary = jobPostingInfo.salary;
 
-      if (jobPostingInfo.workTime === "자유출근제") setFreeHour(true);
+      if (jobPostingInfo.workTime === FREE_HOUR) setFreeHour(true);
 
       setFormData({
         title: jobPostingInfo.title,
@@ -124,7 +125,7 @@ const CreateJobPost = () => {
         employmentType: jobPostingInfo.employmentType,
         salary: jobPostingInfo.salary,
         startHour:
-          jobPostingInfo.workTime === "자유출근제"
+          jobPostingInfo.workTime === FREE_HOUR
             ? new Date(2024, 7, 13, 9, 0)
             : new Date(
                 2024,
@@ -134,7 +135,7 @@ const CreateJobPost = () => {
                 +jobPostingInfo.workTime.slice(3, 5),
               ),
         endHour:
-          jobPostingInfo.workTime === "자유출근제"
+          jobPostingInfo.workTime === FREE_HOUR
             ? new Date(2024, 7, 13, 18, 0)
             : new Date(
                 2024,
@@ -188,9 +189,7 @@ const CreateJobPost = () => {
       education: formData.education,
       employmentType: formData.employmentType,
       salary: +formData.salary,
-      workTime: freeHour
-        ? "자율출근제"
-        : getStringWorkingHour(formData.startHour, formData.endHour),
+      workTime: freeHour ? FREE_HOUR : getStringWorkingHour(formData.startHour, formData.endHour),
       startDate: toLocaleDate(formData.startDate),
       endDate: toLocaleDate(formData.endDate),
       jobPostingContent: formData.jobPostingContent,
@@ -431,8 +430,9 @@ const CreateJobPost = () => {
               />
               <Checkbox
                 id="hourfree"
-                text="자율출근제"
+                text={FREE_HOUR}
                 onChange={event => setFreeHour(event.target.checked)}
+                checked={freeHour}
               />
             </InputContents>
             <ErrorMessage>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -15,7 +15,6 @@ const Index = () => {
   const authUser = useRecoilValue(authUserState);
   const [jobInfos, setJobInfos] = useState<JobInfo[]>([]);
   const [page, setpage] = useState(1);
-  const [loading, setLoading] = useState(false);
   const totalPage = useRef(0);
   const [isInfoMessage, setIsInfoMessage] = useState(false);
 
@@ -25,12 +24,10 @@ const Index = () => {
   useEffect(() => {
     const observer = new IntersectionObserver(
       () => {
-        if (!loading) {
-          setpage(page => {
-            if (page < totalPage.current) return page + 1;
-            else return page;
-          });
-        }
+        setpage(page => {
+          if (page < totalPage.current) return page + 1;
+          else return page;
+        });
       },
       {
         threshold: 0,
@@ -39,18 +36,19 @@ const Index = () => {
     if (observerTarget.current) {
       observer.observe(observerTarget.current);
     }
-  }, [loading]);
+    return () => observer && observer.disconnect();
+  }, []);
 
   useEffect(() => {
     (async () => {
-      setLoading(true);
+      if (!observerTarget.current) return;
+
       const response = await getJobPostings(page);
       totalPage.current = response.totalPages;
 
       if (response.jobPostingsList.length > 0 && jobInfos.length <= (page - 1) * 24) {
         setJobInfos(jobInfos => [...jobInfos, ...response.jobPostingsList]);
       }
-      setLoading(false);
     })();
   }, [jobInfos.length, page]);
 

--- a/src/pages/JobPostDetail.tsx
+++ b/src/pages/JobPostDetail.tsx
@@ -66,7 +66,13 @@ const JobPostDetail = () => {
         if (axios.isAxiosError(e)) {
           if (e.response?.status == 404) {
             alert("마감 기한이 지난 공고 입니다.");
-            navigate(-1);
+            if (!authUser) {
+              navigate("/");
+            } else if (authUser?.role == "ROLE_COMPANY") {
+              navigate("/company-mypage");
+            } else if (authUser?.role == "ROLE_CANDIDATE") {
+              navigate("/user-mypage");
+            }
           }
         }
       }

--- a/src/pages/JobPostDetail.tsx
+++ b/src/pages/JobPostDetail.tsx
@@ -251,7 +251,9 @@ const JobPostDetail = () => {
               </LongInfo>
             </InfoContainer>
           </Container>
-          <ApplyButton onClick={Apply}>지원하기</ApplyButton>
+          {jobPostingInfo.companyKey == authUser?.key || (
+            <ApplyButton onClick={Apply}>지원하기</ApplyButton>
+          )}
         </Inner>
       </Wrapper>
     </>


### PR DESCRIPTION
## 작업 내용

1. 자율출근제 상수로
2. 본인공고는 지원하기 버튼 안보이도록
3. 마감기한지난 공고접근하면 이동할 페이지 유저에 따라서 구분
4. 무한스크롤 일단 한번에 불러와지지는 않는데, 처음에 2페이지까지는 호출되네요..
5. 또 왜 두번씩 호출되는건지..

## 스크린샷(선택)
![image](https://github.com/user-attachments/assets/6037aaf6-eb9e-480d-be4b-7fe814e1a700)

## 리뷰 요구사항
왜이러는건지 알려주세요...


## 연관된 이슈

close #157 
